### PR TITLE
fix(grid): Align components to the grid

### DIFF
--- a/stories/box.js
+++ b/stories/box.js
@@ -14,8 +14,6 @@ const typeMap = {
   D: 4,
   E: 5,
 }
-const types = Object.keys(typeMap)
-
 class Box extends React.PureComponent {
   static displayName = 'Box'
 
@@ -28,7 +26,7 @@ class Box extends React.PureComponent {
   static ALIGN = Item.ALIGN
 
   props: {
-    type: string,
+    type: 'A' | 'B' | 'C' | 'D' | 'E',
     style: Object,
     children: any,
     value?: string,
@@ -37,11 +35,6 @@ class Box extends React.PureComponent {
 
   render() {
     const { type, value = type, children, style, nest, ...props } = this.props
-
-    if (!(type in typeMap)) {
-      throw new Error(`Invalid box type, valid values are: ${types.join(', ')}`)
-    }
-
     const classes = compact([
       styles[`box${typeMap[type]}`],
       nest && `${layout.grid} ${layout.gridMarginNoBottom}`,

--- a/stories/components/header.js
+++ b/stories/components/header.js
@@ -16,7 +16,7 @@ story.add('Header', () => {
   return (
     <WithExtensions notes={notes}>
       <Layout size={Layout.SIZE.AUTO}>
-        <Grid>
+        <Grid root>
           <Grid stretch>
             <Box size={2} type="A" value="Go Back" />
             <Box size={6} type="B">

--- a/stories/components/pagination.js
+++ b/stories/components/pagination.js
@@ -5,6 +5,7 @@ import WithExtensions from '../withExtensions'
 import story from './story'
 import Root from '../root'
 import Box from '../box'
+import Grid from '../../src/grid'
 
 const notes = 'Showcases the rendering of a pagination component'
 
@@ -13,19 +14,21 @@ story.add('Pagination', () => {
 
   return (
     <WithExtensions notes={notes}>
-      <Root size={size}>
-        <Box size={1} type="A" value="<" />
-        <Box size={1} type="A" value="1" />
-        <Box size={1} type="B">...</Box>
-        <Box size={1} type="A" value="5" />
-        <Box size={1} type="A" value="6" />
-        <Box size={1} type="A" value="7" />
-        <Box size={1} type="A" value="8" />
-        <Box size={1} type="A" value="9" />
-        <Box size={1} type="A" value="10" />
-        <Box size={1} type="B">...</Box>
-        <Box size={1} type="A" value="20" />
-        <Box size={1} type="A" value=">" />
+      <Root>
+        <Grid size={size}>
+          <Box size={1} type="A" value="<" />
+          <Box size={1} type="A" value="1" />
+          <Box size={1} type="B">...</Box>
+          <Box size={1} type="A" value="5" />
+          <Box size={1} type="A" value="6" />
+          <Box size={1} type="A" value="7" />
+          <Box size={1} type="A" value="8" />
+          <Box size={1} type="A" value="9" />
+          <Box size={1} type="A" value="10" />
+          <Box size={1} type="B">...</Box>
+          <Box size={1} type="A" value="20" />
+          <Box size={1} type="A" value=">" />
+        </Grid>
       </Root>
     </WithExtensions>
   )

--- a/stories/designGrid.css
+++ b/stories/designGrid.css
@@ -20,6 +20,7 @@
   position: relative;
   margin: 0 auto;
   height: 100%;
+  pointer-events: none;
   max-width: calc(var(--max-width) - var(--page-margin) * 2);
   background-color: transparent;
   background-image: linear-gradient(

--- a/stories/layout/stack.js
+++ b/stories/layout/stack.js
@@ -7,6 +7,7 @@ import Grid from '../../src/grid'
 import Layout from '../../src/layout'
 import { times } from '../../src/utils'
 import { getBoxType } from '../utils'
+import Item from '../../src/item'
 import Box from '../box'
 
 const notes =
@@ -16,12 +17,14 @@ const { AUTO } = Layout.SIZE
 function getStaticSection(index) {
   return (
     <Layout size={AUTO} key={index}>
-      <Grid margin={Grid.MARGIN.NONE}>
-        <Box
-          size={12}
-          type={getBoxType(index)}
-          value={`Section ${index + 1}`}
-        />
+      <Grid root>
+        <Grid>
+          <Box
+            size={12}
+            type={getBoxType(index)}
+            value={`Section ${index + 1}`}
+          />
+        </Grid>
       </Grid>
     </Layout>
   )
@@ -30,7 +33,13 @@ function getStaticSection(index) {
 function getContainerSection(index, subsections) {
   return (
     <Layout key={index}>
-      {times(subsections, i => <div key={i}><h1>SubSection {i + 1}</h1></div>)}
+      <Grid root>
+        {times(subsections, i =>
+          <Grid key={i}>
+            <Item size={12}><h1>SubSection {i + 1}</h1></Item>
+          </Grid>
+        )}
+      </Grid>
     </Layout>
   )
 }
@@ -48,9 +57,7 @@ story.add('Stack', () => {
 
   return (
     <WithExtensions notes={notes}>
-      <Layout>
-        {times(sections, index => getSection(index, subSections))}
-      </Layout>
+      {times(sections, index => getSection(index, subSections))}
     </WithExtensions>
   )
 })

--- a/stories/layout/twoSections.js
+++ b/stories/layout/twoSections.js
@@ -39,7 +39,7 @@ story.add('Two Sections', () => {
           </Layout>
           <Layout>
             <Grid root>
-              <Grid size={12} className={styles.content} align={Grid.ALIGN.TOP}>
+              <Grid className={styles.content} align={Grid.ALIGN.TOP}>
                 <h2>Content</h2>
                 {includeText && <p>{LoremIpsum}</p>}
               </Grid>

--- a/test/__snapshots__/Storyshots.spec.js.snap
+++ b/test/__snapshots__/Storyshots.spec.js.snap
@@ -7,7 +7,7 @@ exports[`Storyshots Components Header 1`] = `
       className="layout layoutAuto"
     >
       <div
-        className="grid"
+        className="gridRoot grid"
       >
         <div
           className="gridStretch grid"
@@ -190,173 +190,177 @@ exports[`Storyshots Components Pagination 1`] = `
       className="layout layoutStretch"
     >
       <div
-        className="gridRoot col-12 grid"
+        className="gridRoot grid"
       >
         <div
-          className="col-1"
+          className="col-12 grid"
         >
           <div
-            className="box1"
-            style={Object {}}
+            className="col-1"
           >
             <div
-              className="gridMiddle gridCenter grid"
+              className="box1"
+              style={Object {}}
             >
-              &lt;
+              <div
+                className="gridMiddle gridCenter grid"
+              >
+                &lt;
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="col-1"
-        >
           <div
-            className="box1"
-            style={Object {}}
+            className="col-1"
           >
             <div
-              className="gridMiddle gridCenter grid"
+              className="box1"
+              style={Object {}}
             >
-              1
+              <div
+                className="gridMiddle gridCenter grid"
+              >
+                1
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="col-1"
-        >
           <div
-            className="box2"
-            style={Object {}}
+            className="col-1"
           >
             <div
-              className="gridMiddle gridCenter grid"
+              className="box2"
+              style={Object {}}
             >
-              ...
+              <div
+                className="gridMiddle gridCenter grid"
+              >
+                ...
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="col-1"
-        >
           <div
-            className="box1"
-            style={Object {}}
+            className="col-1"
           >
             <div
-              className="gridMiddle gridCenter grid"
+              className="box1"
+              style={Object {}}
             >
-              5
+              <div
+                className="gridMiddle gridCenter grid"
+              >
+                5
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="col-1"
-        >
           <div
-            className="box1"
-            style={Object {}}
+            className="col-1"
           >
             <div
-              className="gridMiddle gridCenter grid"
+              className="box1"
+              style={Object {}}
             >
-              6
+              <div
+                className="gridMiddle gridCenter grid"
+              >
+                6
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="col-1"
-        >
           <div
-            className="box1"
-            style={Object {}}
+            className="col-1"
           >
             <div
-              className="gridMiddle gridCenter grid"
+              className="box1"
+              style={Object {}}
             >
-              7
+              <div
+                className="gridMiddle gridCenter grid"
+              >
+                7
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="col-1"
-        >
           <div
-            className="box1"
-            style={Object {}}
+            className="col-1"
           >
             <div
-              className="gridMiddle gridCenter grid"
+              className="box1"
+              style={Object {}}
             >
-              8
+              <div
+                className="gridMiddle gridCenter grid"
+              >
+                8
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="col-1"
-        >
           <div
-            className="box1"
-            style={Object {}}
+            className="col-1"
           >
             <div
-              className="gridMiddle gridCenter grid"
+              className="box1"
+              style={Object {}}
             >
-              9
+              <div
+                className="gridMiddle gridCenter grid"
+              >
+                9
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="col-1"
-        >
           <div
-            className="box1"
-            style={Object {}}
+            className="col-1"
           >
             <div
-              className="gridMiddle gridCenter grid"
+              className="box1"
+              style={Object {}}
             >
-              10
+              <div
+                className="gridMiddle gridCenter grid"
+              >
+                10
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="col-1"
-        >
           <div
-            className="box2"
-            style={Object {}}
+            className="col-1"
           >
             <div
-              className="gridMiddle gridCenter grid"
+              className="box2"
+              style={Object {}}
             >
-              ...
+              <div
+                className="gridMiddle gridCenter grid"
+              >
+                ...
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="col-1"
-        >
           <div
-            className="box1"
-            style={Object {}}
+            className="col-1"
           >
             <div
-              className="gridMiddle gridCenter grid"
+              className="box1"
+              style={Object {}}
             >
-              20
+              <div
+                className="gridMiddle gridCenter grid"
+              >
+                20
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          className="col-1"
-        >
           <div
-            className="box1"
-            style={Object {}}
+            className="col-1"
           >
             <div
-              className="gridMiddle gridCenter grid"
+              className="box1"
+              style={Object {}}
             >
-              &gt;
+              <div
+                className="gridMiddle gridCenter grid"
+              >
+                &gt;
+              </div>
             </div>
           </div>
         </div>
@@ -2495,13 +2499,13 @@ exports[`Storyshots Layout Stack 1`] = `
 <div>
   <div>
     <div
-      className="layout layoutStretch"
+      className="layout layoutAuto"
     >
       <div
-        className="layout layoutAuto"
+        className="gridRoot grid"
       >
         <div
-          className="gridMarginNone grid"
+          className="grid"
         >
           <div
             className="col-12"
@@ -2519,26 +2523,48 @@ exports[`Storyshots Layout Stack 1`] = `
           </div>
         </div>
       </div>
+    </div>
+    <div
+      className="layout layoutStretch"
+    >
       <div
-        className="layout layoutStretch"
+        className="gridRoot grid"
       >
-        <div>
-          <h1>
-            SubSection 
-            1
-          </h1>
+        <div
+          className="grid"
+        >
+          <div
+            className="col-12"
+          >
+            <h1>
+              SubSection 
+              1
+            </h1>
+          </div>
         </div>
-        <div>
-          <h1>
-            SubSection 
-            2
-          </h1>
+        <div
+          className="grid"
+        >
+          <div
+            className="col-12"
+          >
+            <h1>
+              SubSection 
+              2
+            </h1>
+          </div>
         </div>
-        <div>
-          <h1>
-            SubSection 
-            3
-          </h1>
+        <div
+          className="grid"
+        >
+          <div
+            className="col-12"
+          >
+            <h1>
+              SubSection 
+              3
+            </h1>
+          </div>
         </div>
       </div>
     </div>
@@ -2600,7 +2626,7 @@ exports[`Storyshots Layout Two Sections 1`] = `
             className="gridRoot grid"
           >
             <div
-              className="content gridTop col-12 grid"
+              className="content gridTop grid"
             >
               <h2>
                 Content

--- a/yarn.lock
+++ b/yarn.lock
@@ -4380,11 +4380,11 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@4.17.2, lodash@^4.0.0, lodash@^4.15.0:
+lodash@4.17.2:
   version "4.17.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.2.tgz#34a3055babe04ce42467b607d700072c7ff6bf42"
 
-lodash@4.x.x, lodash@^4.0.1, lodash@^4.1.0, lodash@^4.11.2, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
+lodash@4.x.x, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.0, lodash@^4.11.2, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 


### PR DESCRIPTION
Fixes components not aligning to the top level grid (where appropriate)

Layout cases still need to be fixed (as part of https://github.com/obartra/reflex/issues/56 and https://github.com/obartra/reflex/issues/40)

Closes https://github.com/obartra/reflex/issues/60