### PR TITLE
fix(layout): Update layout system

### DIFF
--- a/src/grid.css
+++ b/src/grid.css
@@ -5,10 +5,12 @@
   display: flex;
   flex-flow: row wrap;
   width: 100%;
+  max-width: var(--max-width);
 
   &.gridRoot {
     padding-left: calc(var(--page-margin) - var(--gutter) / 2);
     padding-right: calc(var(--page-margin) - var(--gutter) / 2);
+    margin: auto;
     min-width: var(--min-width);
   }
 }

--- a/src/layout.css
+++ b/src/layout.css
@@ -1,32 +1,35 @@
-@import "./variables";
-@import "./grid";
-
-.layout {
+.parent, .auto, .stretch {
   box-sizing: border-box;
+  width: 100%;
+}
+
+.parent {
+  align-items: center;
   display: flex;
   flex-flow: column;
-  align-items: center;
-  width: 100%;
+  flex-grow: 1;
+  height: 100%;
+}
+
+.overflow {
   overflow-y: auto;
-  flex: 1;
+}
 
-  &.layoutAuto {
-    flex: initial;
-  }
+.auto {
+  flex-grow: 0;
+  flex-shrink: 0;
+}
 
-  &.layoutStretch {
-    height: 100%;
-  }
+.stretch {
+  flex-grow: 1;
+}
 
-  &.layoutFit {
-    min-height: 100%;
-  }
+.fixedTop {
+  position: fixed;
+  top: 0;
+}
 
-  & > .grid {
-    max-width: var(--max-width);
-  }
-
-  & > * {
-    flex: 1;
-  }
+.fixedBottom {
+  position: fixed;
+  bottom: 0;
 }

--- a/src/layout.hoc.js
+++ b/src/layout.hoc.js
@@ -1,19 +1,41 @@
 // @flow
 import React from 'react'
 import { compact, getDisplayName } from './utils'
-import { SIZE } from './values'
-import styles from './index.css'
+import { LAYOUT, FIXED_POSITION, OVERFLOW } from './values'
+import styles from './layout.css'
 
-function getSize(size: Symbol | void) {
-  const prefix = 'layout'
+function getLayout(layout: Symbol | void): string {
+  switch (layout) {
+    case LAYOUT.PARENT:
+      return styles.parent
+    case LAYOUT.STRETCH:
+      return styles.stretch
+    case LAYOUT.AUTO:
+    /* intentional fall through */
+    default:
+      return styles.auto
+  }
+}
 
-  switch (size) {
-    case SIZE.AUTO:
-      return styles[`${prefix}Auto`]
-    case SIZE.STRETCH:
-      return styles[`${prefix}Stretch`]
-    case SIZE.FIT:
-      return styles[`${prefix}Fit`]
+function getFixed(fixed: Symbol | void): string {
+  switch (fixed) {
+    case FIXED_POSITION.TOP:
+      return styles.fixedTop
+    case FIXED_POSITION.BOTTOM:
+      return styles.fixedBottom
+    case FIXED_POSITION.NONE:
+    /* intentional fall through */
+    default:
+      return ''
+  }
+}
+
+function getOverflow(overflow: Symbol | void): string {
+  switch (overflow) {
+    case OVERFLOW.AUTO:
+      return styles.overflow
+    case OVERFLOW.NONE:
+    /* intentional fall through */
     default:
       return ''
   }
@@ -23,23 +45,35 @@ export default function Layout(Component: any) {
   return class withGrid extends React.PureComponent {
     props: {
       className?: String,
-      size?: Symbol,
+      type?: Symbol,
+      fixed?: Symbol,
+      overflow?: Symbol,
     }
 
     static defaultProps = {
       className: undefined,
-      size: SIZE.STRETCH,
+      type: LAYOUT.AUTO,
+      fixed: FIXED_POSITION.NONE,
+      overflow: OVERFLOW.NONE,
     }
 
     render() {
-      const { className, size, ...props } = this.props
-      const classes = compact([styles.layout, className, getSize(size)])
+      const { className, type, fixed, overflow, ...props } = this.props
+      const classes = compact([
+        styles.layout,
+        className,
+        getLayout(type),
+        getFixed(fixed),
+        getOverflow(overflow),
+      ])
 
       return <Component {...props} className={classes.join(' ')} />
     }
 
     static displayName = `withLayout(${getDisplayName(Component)})`
 
-    static SIZE = SIZE
+    static TYPE = LAYOUT
+    static FIXED_POSITION = FIXED_POSITION
+    static OVERFLOW = OVERFLOW
   }
 }

--- a/src/values.js
+++ b/src/values.js
@@ -10,10 +10,10 @@ export const JUSTIFY = {
   RIGHT: Symbol('JUSTIFY_RIGHT'),
 }
 
-export const SIZE = {
-  AUTO: Symbol('SIZE_AUTO'),
-  FIT: Symbol('SIZE_FIT'),
-  STRETCH: Symbol('SIZE_STRETCH'),
+export const LAYOUT = {
+  PARENT: Symbol('LAYOUT_PARENT'),
+  AUTO: Symbol('LAYOUT_AUTO'),
+  STRETCH: Symbol('LAYOUT_STRETCH'),
 }
 
 export const MARGIN = {
@@ -28,4 +28,15 @@ export const MARGIN_SIZE = {
   DEFAULT: Symbol('MARGIN_SIZE_DEFAULT'),
   DOUBLE: Symbol('MARGIN_SIZE_DOUBLE'),
   HALF: Symbol('MARGIN_SIZE_HALF'),
+}
+
+export const FIXED_POSITION = {
+  NONE: Symbol('AUTO_FLOW'),
+  TOP: Symbol('TOP'),
+  BOTTOM: Symbol('BOTTOM'),
+}
+
+export const OVERFLOW = {
+  AUTO: Symbol('SCROLLBARS'),
+  NONE: Symbol('OVERFLOW'),
 }

--- a/stories/components/header.js
+++ b/stories/components/header.js
@@ -10,7 +10,7 @@ export default function() {
 
   return (
     <WithExtensions notes={notes}>
-      <Layout size={Layout.SIZE.AUTO}>
+      <Layout type={Layout.TYPE.PARENT}>
         <Grid root>
           <Grid stretch>
             <Box size={2} type="A" value="Go Back" />

--- a/stories/core/root.js
+++ b/stories/core/root.js
@@ -4,7 +4,7 @@ import { Grid, Layout } from '../../src'
 
 export default function Root(props: Grid.Props) {
   return (
-    <Layout size={Layout.SIZE.STRETCH}>
+    <Layout type={Layout.TYPE.PARENT}>
       <Grid {...props} root />
     </Layout>
   )

--- a/stories/grid/autoflow.js
+++ b/stories/grid/autoflow.js
@@ -14,7 +14,7 @@ export default function() {
 
   return (
     <WithExtensions notes={notes}>
-      <Layout size={Layout.SIZE.AUTO}>
+      <Layout type={Layout.TYPE.PARENT}>
         <Grid {...props} root>
           <Box size={1} type="A" value="1" />
           <Box size={2} type="A" value="2" />

--- a/stories/layout/holyGrail.js
+++ b/stories/layout/holyGrail.js
@@ -5,7 +5,9 @@ import { Grid, Layout } from '../../src'
 import { WithExtensions, loremIpsum } from '../core'
 import styles from './layout.css'
 
-const { FIT, AUTO } = Layout.SIZE
+const { PARENT, AUTO, STRETCH } = Layout.TYPE
+const { TOP } = Layout.FIXED_POSITION
+
 const notes =
   'An implementation of the Holy Grail layout using the grid and layout systems. The maximum content width is limited to the page width and the hight is either the page height or content height, whichever is larger'
 
@@ -14,28 +16,26 @@ export default function() {
 
   return (
     <WithExtensions notes={notes}>
-      <Layout size={FIT} className={styles.page}>
-        <Layout size={AUTO} className={styles.header}>
+      <Layout type={PARENT} className={styles.page}>
+        <Layout className={styles.header} fixed={TOP}>
           <Grid root>
             <h1>Header</h1>
           </Grid>
         </Layout>
-        <Layout>
-          <Layout>
-            <Grid root>
-              <Grid size={2} className={styles.nav}><h2>Nav</h2></Grid>
-              <Grid size={8} className={styles.content} align={Grid.ALIGN.TOP}>
-                <h2>Content</h2>
-                {includeText && <p>{loremIpsum}</p>}
-              </Grid>
-              <Grid size={2} className={styles.ads}><h2>Ads</h2></Grid>
+        <Layout type={STRETCH} className={styles.main}>
+          <Grid root>
+            <Grid size={2} className={styles.nav}><h2>Nav</h2></Grid>
+            <Grid size={8} className={styles.content} align={Grid.ALIGN.TOP}>
+              <h2>Content</h2>
+              {includeText && <p>{loremIpsum}</p>}
             </Grid>
-          </Layout>
-          <Layout size={AUTO} className={styles.footer}>
-            <Grid root>
-              <h1>Footer</h1>
-            </Grid>
-          </Layout>
+            <Grid size={2} className={styles.ads}><h2>Ads</h2></Grid>
+          </Grid>
+        </Layout>
+        <Layout type={AUTO} className={styles.footer}>
+          <Grid root>
+            <h1>Footer</h1>
+          </Grid>
         </Layout>
       </Layout>
     </WithExtensions>

--- a/stories/layout/layout.css
+++ b/stories/layout/layout.css
@@ -1,6 +1,12 @@
 @import "../core/variables.css";
 
 .page {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+
   & h1, & h2, & .nav > *, & .content > *, & .ads > * {
     margin: 10px;
   }
@@ -15,6 +21,10 @@
   & input {
     outline: 1px solid var(--axonBlack);
     border: 0;
+  }
+
+  & .main {
+    margin-top: 57px; /* header height, hard coded offset */
   }
 
   & button {

--- a/stories/layout/stack.js
+++ b/stories/layout/stack.js
@@ -7,13 +7,13 @@ import style from './layout.css'
 
 const notes =
   'A layout component defaults to vertically stacking elements, taking the full width and optionally sizing to fit or stretching elements'
-const { AUTO } = Layout.SIZE
+const { AUTO, PARENT } = Layout.TYPE
 
 function getStaticSection(index) {
   return (
-    <Layout size={AUTO} key={index}>
+    <Layout type={AUTO} key={index}>
       <Grid root>
-        <Grid>
+        <Grid margin={Grid.MARGIN.NONE}>
           <Box size={12} type="C" value={`Section ${index + 1}`} />
         </Grid>
       </Grid>
@@ -23,7 +23,7 @@ function getStaticSection(index) {
 
 function getContainerSection(index, subsections) {
   return (
-    <Layout key={index}>
+    <Layout key={index} type={PARENT} overflow={Layout.OVERFLOW.AUTO}>
       <Grid root>
         {utils.times(subsections, i =>
           <Grid key={i}>
@@ -48,9 +48,13 @@ export default function() {
 
   return (
     <WithExtensions notes={notes}>
-      <div className={style.page}>
+      <Layout
+        type={PARENT}
+        className={style.page}
+        overflow={Layout.OVERFLOW.AUTO}
+      >
         {utils.times(sections, index => getSection(index, subSections))}
-      </div>
+      </Layout>
     </WithExtensions>
   )
 }

--- a/stories/layout/twoSections.js
+++ b/stories/layout/twoSections.js
@@ -5,7 +5,8 @@ import { Grid, Item, Layout } from '../../src'
 import { WithExtensions, loremIpsum } from '../core'
 import styles from './layout.css'
 
-const { FIT, AUTO } = Layout.SIZE
+const { PARENT, AUTO, STRETCH } = Layout.TYPE
+const { TOP } = Layout.FIXED_POSITION
 
 export default function() {
   const includeText = boolean('Show text', false)
@@ -14,14 +15,14 @@ export default function() {
 
   return (
     <WithExtensions notes={notes}>
-      <Layout size={FIT} className={styles.page}>
-        <Layout size={AUTO} className={styles.header}>
+      <Layout type={PARENT} className={styles.page}>
+        <Layout className={styles.header} fixed={TOP}>
           <Grid root>
             <h1>Header</h1>
           </Grid>
         </Layout>
-        <Layout>
-          <Layout size={AUTO} className={styles.top}>
+        <Layout type={PARENT} className={styles.main}>
+          <Layout type={AUTO} className={styles.top}>
             <Grid root>
               <Grid>
                 <Item size={6} offset={2}>
@@ -33,7 +34,7 @@ export default function() {
               </Grid>
             </Grid>
           </Layout>
-          <Layout>
+          <Layout type={STRETCH}>
             <Grid root>
               <Grid className={styles.content} align={Grid.ALIGN.TOP}>
                 <h2>Content</h2>
@@ -41,7 +42,7 @@ export default function() {
               </Grid>
             </Grid>
           </Layout>
-          <Layout size={AUTO} className={styles.footer}>
+          <Layout type={AUTO} className={styles.footer}>
             <Grid root>
               <h1>Footer</h1>
             </Grid>

--- a/test/__snapshots__/Storyshots.spec.js.snap
+++ b/test/__snapshots__/Storyshots.spec.js.snap
@@ -4,7 +4,7 @@ exports[`Storyshots Components Header 1`] = `
 <div>
   <div>
     <div
-      className="layout layoutAuto"
+      className="layout parent"
     >
       <div
         className="gridRoot grid"
@@ -187,7 +187,7 @@ exports[`Storyshots Components Pagination 1`] = `
 <div>
   <div>
     <div
-      className="layout layoutStretch"
+      className="layout parent"
     >
       <div
         className="gridRoot grid"
@@ -374,7 +374,7 @@ exports[`Storyshots Grid Autoflow 1`] = `
 <div>
   <div>
     <div
-      className="layout layoutAuto"
+      className="layout parent"
     >
       <div
         className="gridRoot gridStretch grid"
@@ -533,7 +533,7 @@ exports[`Storyshots Grid Fraction 1`] = `
 <div>
   <div>
     <div
-      className="layout layoutStretch"
+      className="layout parent"
     >
       <div
         className="gridRoot grid"
@@ -1198,7 +1198,7 @@ exports[`Storyshots Grid Horizontal Align 1`] = `
 <div>
   <div>
     <div
-      className="layout layoutStretch"
+      className="layout parent"
     >
       <div
         className="gridRoot grid"
@@ -1285,7 +1285,7 @@ exports[`Storyshots Grid Nested 1`] = `
 <div>
   <div>
     <div
-      className="layout layoutStretch"
+      className="layout parent"
     >
       <div
         className="gridRoot grid"
@@ -1559,7 +1559,7 @@ exports[`Storyshots Grid Offset 1`] = `
 <div>
   <div>
     <div
-      className="layout layoutStretch"
+      className="layout parent"
     >
       <div
         className="gridRoot grid"
@@ -1780,7 +1780,7 @@ exports[`Storyshots Grid Sizing 1`] = `
 <div>
   <div>
     <div
-      className="layout layoutStretch"
+      className="layout parent"
     >
       <div
         className="gridRoot grid"
@@ -2229,7 +2229,7 @@ exports[`Storyshots Grid Vertical Align 1`] = `
 <div>
   <div>
     <div
-      className="layout layoutStretch"
+      className="layout parent"
     >
       <div
         className="gridRoot grid"
@@ -2433,10 +2433,10 @@ exports[`Storyshots Layout Holy Grail 1`] = `
 <div>
   <div>
     <div
-      className="layout page layoutFit"
+      className="layout page parent"
     >
       <div
-        className="layout header layoutAuto"
+        className="layout header auto fixedTop"
       >
         <div
           className="gridRoot grid"
@@ -2447,47 +2447,43 @@ exports[`Storyshots Layout Holy Grail 1`] = `
         </div>
       </div>
       <div
-        className="layout layoutStretch"
+        className="layout main stretch"
       >
         <div
-          className="layout layoutStretch"
+          className="gridRoot grid"
         >
           <div
-            className="gridRoot grid"
+            className="nav col-2 grid"
           >
-            <div
-              className="nav col-2 grid"
-            >
-              <h2>
-                Nav
-              </h2>
-            </div>
-            <div
-              className="content gridTop col-8 grid"
-            >
-              <h2>
-                Content
-              </h2>
-            </div>
-            <div
-              className="ads col-2 grid"
-            >
-              <h2>
-                Ads
-              </h2>
-            </div>
+            <h2>
+              Nav
+            </h2>
+          </div>
+          <div
+            className="content gridTop col-8 grid"
+          >
+            <h2>
+              Content
+            </h2>
+          </div>
+          <div
+            className="ads col-2 grid"
+          >
+            <h2>
+              Ads
+            </h2>
           </div>
         </div>
+      </div>
+      <div
+        className="layout footer auto"
+      >
         <div
-          className="layout footer layoutAuto"
+          className="gridRoot grid"
         >
-          <div
-            className="gridRoot grid"
-          >
-            <h1>
-              Footer
-            </h1>
-          </div>
+          <h1>
+            Footer
+          </h1>
         </div>
       </div>
     </div>
@@ -2499,16 +2495,16 @@ exports[`Storyshots Layout Stack 1`] = `
 <div>
   <div>
     <div
-      className="page"
+      className="layout page parent overflow"
     >
       <div
-        className="layout layoutAuto"
+        className="layout auto"
       >
         <div
           className="gridRoot grid"
         >
           <div
-            className="grid"
+            className="gridMarginNone grid"
           >
             <div
               className="col-12"
@@ -2528,7 +2524,7 @@ exports[`Storyshots Layout Stack 1`] = `
         </div>
       </div>
       <div
-        className="layout layoutStretch"
+        className="layout parent overflow"
       >
         <div
           className="gridRoot grid"
@@ -2580,10 +2576,10 @@ exports[`Storyshots Layout Two Sections 1`] = `
 <div>
   <div>
     <div
-      className="layout page layoutFit"
+      className="layout page parent"
     >
       <div
-        className="layout header layoutAuto"
+        className="layout header auto fixedTop"
       >
         <div
           className="gridRoot grid"
@@ -2594,10 +2590,10 @@ exports[`Storyshots Layout Two Sections 1`] = `
         </div>
       </div>
       <div
-        className="layout layoutStretch"
+        className="layout main parent"
       >
         <div
-          className="layout top layoutAuto"
+          className="layout top auto"
         >
           <div
             className="gridRoot grid"
@@ -2624,7 +2620,7 @@ exports[`Storyshots Layout Two Sections 1`] = `
           </div>
         </div>
         <div
-          className="layout layoutStretch"
+          className="layout stretch"
         >
           <div
             className="gridRoot grid"
@@ -2639,7 +2635,7 @@ exports[`Storyshots Layout Two Sections 1`] = `
           </div>
         </div>
         <div
-          className="layout footer layoutAuto"
+          className="layout footer auto"
         >
           <div
             className="gridRoot grid"


### PR DESCRIPTION
These changes simplify the layout to 3 types:

- PARENT: Contains stretch or auto elements, expands to 100% of the container
- STRETCH: Grows to fit, vertical overflow if needed
- AUTO: Size defined by the content, doesn't grow or shrink

To lock a layout element to the top or the bottom of the window you can use: `fixed={Layout.FIXED_POSITION.TOP}` or `fixed={Layout.FIXED_POSITION.TOP}`. This is used by sticky headers while preserving the page scroll.

To change the default overflow setting (overflow: auto) you can set `overflow={Layout.OVERFLOW.NONE}`

Closes https://github.com/obartra/reflex/issues/56