### PR TITLE
refactor(dependencies): Use lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "postcss-loader": "2.0.5",
     "postcss-nesting": "4.0.1",
     "prettier": "1.4.4",
-    "react-element-to-jsx-string": "10.1.0",
     "raw-loader": "0.5.1",
+    "react-element-to-jsx-string": "10.1.0",
     "react-test-renderer": "15.5.4",
     "regenerator-runtime": "0.10.5",
     "screener-storybook": "0.7.2",
@@ -84,6 +84,7 @@
     "@storybook/addon-knobs": "3.0.1",
     "@storybook/addon-notes": "3.1.2",
     "@storybook/react": "3.1.3",
+    "lodash": "4.17.4",
     "react": "15.5.4",
     "react-dom": "15.5.4"
   },

--- a/src/grid.hoc.js
+++ b/src/grid.hoc.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react'
-import { compact, getDisplayName, getMargin, log } from './utils'
+import { compact } from 'lodash'
+import { getDisplayName, getMargin, log } from './utils'
 import type {
   AlignGrid,
   Justify,

--- a/src/item.hoc.js
+++ b/src/item.hoc.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react'
-import { compact, getDisplayName } from './utils'
+import { compact } from 'lodash'
+import { getDisplayName } from './utils'
 import type { Size, AlignItem, Offset } from './types'
 import styles from './index.css'
 

--- a/src/layout.hoc.js
+++ b/src/layout.hoc.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react'
-import { compact, getDisplayName, getMargin } from './utils'
+import { compact } from 'lodash'
+import { getDisplayName, getMargin } from './utils'
 import type { Margin, MarginSize, Overflow, Fixed, LayoutType } from './types'
 import styles from './index.css'
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 // @flow
 import styles from './index.css'
-import { type Component, type Margin, type MarginSize } from './types'
+import type { Component, Margin, MarginSize } from './types'
 
 /* eslint-disable no-unused-vars */
 const noop = (...params: any[]) => null
@@ -15,17 +15,6 @@ export function getDisplayName(WrappedComponent: string | Component): string {
   }
 
   return WrappedComponent || defaultName
-}
-
-export function compact(array: any[] = []) {
-  return array.filter(el => !!el)
-}
-
-export function times(
-  number: number = 0,
-  callback: (index: number) => any = noop
-) {
-  return Array.from(Array(number)).map((value, index) => callback(index))
 }
 
 function getMarginSizeClassName(size: MarginSize | void) {
@@ -60,16 +49,6 @@ export function getMargin(
     default:
       return ''
   }
-}
-
-export function fromPairs(pairs: [string, any][]): Object {
-  return pairs.reduce(
-    (acc, [key, value]) => ({
-      ...acc,
-      [key]: value,
-    }),
-    {}
-  )
 }
 
 /* eslint-disable no-console */

--- a/stories/components/header.js
+++ b/stories/components/header.js
@@ -1,7 +1,8 @@
 // @flow
 import React from 'react'
+import { times } from 'lodash'
 import { number } from '@storybook/addon-knobs'
-import { Grid, Layout, utils } from '../../src'
+import { Grid, Layout } from '../../src'
 import { WithExtensions, Box } from '../core'
 
 export default function() {
@@ -22,7 +23,7 @@ export default function() {
           </Grid>
           <Grid>
             <Grid size={10}>
-              {utils.times(items, i =>
+              {times(items, i =>
                 <Box size={1} type="A" key={i} value={`${i + 1}`} />
               )}
             </Grid>

--- a/stories/core/box.js
+++ b/stories/core/box.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react'
-import { Grid, ItemHOC, utils } from '../../src'
+import { compact } from 'lodash'
+import { Grid, ItemHOC } from '../../src'
 import styles from './stories.css'
 import layout from '../../src/index.css'
 
@@ -29,7 +30,7 @@ class Box extends React.PureComponent {
 
   render() {
     const { type, value = type, children, style, nest, ...props } = this.props
-    const classes = utils.compact([
+    const classes = compact([
       styles[`box${typeMap[type]}`],
       nest && `${layout.grid} ${layout.gridMarginNoBottom}`,
     ])

--- a/stories/core/storyFolders.js
+++ b/stories/core/storyFolders.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { utils } from '../../src'
+import { fromPairs } from 'lodash'
 
 const { readdirSync, lstatSync } = require('fs')
 const { join } = require('path')
@@ -20,7 +20,7 @@ type keyFunctionPair = {
  * makes this API less clean
  */
 function loadTest(folder: string): keyFunctionPair {
-  return utils.fromPairs(
+  return fromPairs(
     readdirSync(join(__dirname, folder))
       .map(filename => join(__dirname, folder, filename))
       .filter(filepath => !lstatSync(filepath).isDirectory())
@@ -32,7 +32,7 @@ function loadTest(folder: string): keyFunctionPair {
 }
 
 function loadWebpack(folder: Function): keyFunctionPair {
-  return utils.fromPairs(
+  return fromPairs(
     folder.keys().map(filename => [filename, folder(filename).default])
   )
 }

--- a/stories/grid/autoflow.js
+++ b/stories/grid/autoflow.js
@@ -1,7 +1,8 @@
 // @flow
 import React from 'react'
+import { times } from 'lodash'
 import { number, boolean } from '@storybook/addon-knobs'
-import { Grid, Layout, utils } from '../../src'
+import { Grid, Layout } from '../../src'
 import { WithExtensions, Box, getMarginSelect } from '../core'
 
 export default function() {
@@ -28,10 +29,8 @@ export default function() {
               height: 100,
             }}
           />
-          {utils.times(
-            number('items', 5, { range: true, min: 0, max: 100 }),
-            index =>
-              <Box size={2} key={index} type="A" value={`${index + 6}`} />
+          {times(number('items', 5, { range: true, min: 0, max: 100 }), index =>
+            <Box size={2} key={index} type="A" value={`${index + 6}`} />
           )}
         </Grid>
       </Layout>

--- a/stories/grid/fraction.js
+++ b/stories/grid/fraction.js
@@ -1,7 +1,8 @@
 // @flow
 import React from 'react'
+import { times } from 'lodash'
 import { number } from '@storybook/addon-knobs'
-import { Grid, utils } from '../../src'
+import { Grid } from '../../src'
 import { WithExtensions, Root, Box, getMarginSelect } from '../core'
 
 export default function() {
@@ -14,9 +15,9 @@ export default function() {
     <WithExtensions notes={notes}>
       <Root>
         <h1>Auto Size</h1>
-        {utils.times(9, size =>
+        {times(9, size =>
           <Grid {...margin} key={size}>
-            {utils.times(size + items, i =>
+            {times(size + items, i =>
               <Box key={i} type="A" value={`1 / ${size + items}`} />
             )}
           </Grid>
@@ -37,13 +38,13 @@ export default function() {
 
         <h1>Custom</h1>
         <Grid {...margin}>
-          {utils.times(items, index =>
+          {times(items, index =>
             <Box key={index} type="A" value={`${index + 1}`} />
           )}
         </Grid>
         <Grid {...margin}>
           <Box size={6} type="A" value="6 (fixed)" />
-          {utils.times(items, index =>
+          {times(items, index =>
             <Box key={index} type="A" value={`${index + 2}`} />
           )}
         </Grid>

--- a/stories/grid/nested.js
+++ b/stories/grid/nested.js
@@ -1,7 +1,8 @@
 // @flow
 import React from 'react'
 import { number } from '@storybook/addon-knobs'
-import { Grid, utils } from '../../src'
+import { times } from 'lodash'
+import { Grid } from '../../src'
 import { WithExtensions, Root, Box } from '../core'
 
 export default function() {
@@ -33,7 +34,7 @@ export default function() {
         </Grid>
         <Grid>
           <Box size={6} type="B" grid nest>
-            {utils.times(items, index =>
+            {times(items, index =>
               <Box key={index} size={1} type="A" value={`${index % 12 + 1}`} />
             )}
           </Box>

--- a/stories/grid/sizing.js
+++ b/stories/grid/sizing.js
@@ -1,7 +1,8 @@
 // @flow
 import React from 'react'
+import { times } from 'lodash'
 import { number } from '@storybook/addon-knobs'
-import { Grid, utils } from '../../src'
+import { Grid } from '../../src'
 import { WithExtensions, Root, Box } from '../core'
 
 export default function() {
@@ -13,19 +14,19 @@ export default function() {
     <WithExtensions notes={notes}>
       <Root>
         <Grid>
-          {utils.times(12, i => <Box key={i} size={1} type="A" value="1" />)}
+          {times(12, i => <Box key={i} size={1} type="A" value="1" />)}
         </Grid>
         <Grid>
-          {utils.times(6, i => <Box key={i} size={2} type="A" value="2" />)}
+          {times(6, i => <Box key={i} size={2} type="A" value="2" />)}
         </Grid>
         <Grid>
-          {utils.times(4, i => <Box key={i} size={3} type="A" value="3" />)}
+          {times(4, i => <Box key={i} size={3} type="A" value="3" />)}
         </Grid>
         <Grid>
-          {utils.times(3, i => <Box key={i} size={4} type="A" value="4" />)}
+          {times(3, i => <Box key={i} size={4} type="A" value="4" />)}
         </Grid>
         <Grid>
-          {utils.times(2, i => <Box key={i} size={6} type="A" value="6" />)}
+          {times(2, i => <Box key={i} size={6} type="A" value="6" />)}
         </Grid>
         <Grid>
           <Box type="A" value="Auto" />

--- a/stories/grid/verticalAlign.js
+++ b/stories/grid/verticalAlign.js
@@ -1,7 +1,8 @@
 // @flow
 import React from 'react'
+import { times } from 'lodash'
 import { boolean, number } from '@storybook/addon-knobs'
-import { Grid, utils } from '../../src'
+import { Grid } from '../../src'
 import { getMarginSelect, Root, Box, WithExtensions } from '../core'
 
 function ReferenceColumn({ height }: { height: number }) {
@@ -51,9 +52,7 @@ export default function() {
             align={stretch ? 'stretch' : 'top'}
             style={{ height }}
           >
-            {utils.times(items, i =>
-              <Box size={12} key={i} type="C" value="TOP" />
-            )}
+            {times(items, i => <Box size={12} key={i} type="C" value="TOP" />)}
           </Grid>
           <Grid
             size={4}
@@ -61,7 +60,7 @@ export default function() {
             align={stretch ? 'stretch' : 'middle'}
             style={{ height }}
           >
-            {utils.times(items, i =>
+            {times(items, i =>
               <Box size={12} key={i} type="C" value="MIDDLE" />
             )}
           </Grid>
@@ -71,7 +70,7 @@ export default function() {
             align={stretch ? 'stretch' : 'bottom'}
             style={{ height }}
           >
-            {utils.times(items, i =>
+            {times(items, i =>
               <Box size={12} key={i} type="C" value="BOTTOM" />
             )}
           </Grid>

--- a/stories/layout/stack.js
+++ b/stories/layout/stack.js
@@ -1,7 +1,8 @@
 // @flow
 import React from 'react'
+import { times } from 'lodash'
 import { number } from '@storybook/addon-knobs'
-import { Grid, Layout, Item, utils } from '../../src'
+import { Grid, Layout, Item } from '../../src'
 import { WithExtensions, Box } from '../core'
 import style from './layout.css'
 
@@ -24,7 +25,7 @@ function getContainerSection(index, subsections) {
   return (
     <Layout key={index} type="parent" overflow="scrollbars">
       <Grid root>
-        {utils.times(subsections, i =>
+        {times(subsections, i =>
           <Grid key={i}>
             <Item size={12}><h1>SubSection {i + 1}</h1></Item>
           </Grid>
@@ -48,7 +49,7 @@ export default function() {
   return (
     <WithExtensions notes={notes}>
       <Layout type="parent" className={style.page}>
-        {utils.times(sections, index => getSection(index, subSections))}
+        {times(sections, index => getSection(index, subSections))}
       </Layout>
     </WithExtensions>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -153,8 +153,8 @@
     redux "^3.6.0"
 
 "@types/react@^15.0.24":
-  version "15.0.28"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-15.0.28.tgz#0120d64ca143b74196324ccbe132d09df48a8d46"
+  version "15.0.29"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-15.0.29.tgz#a10831b9d025bcef6cab7bc1c6547bdddbabc938"
 
 JSONStream@^0.8.4:
   version "0.8.4"
@@ -243,10 +243,12 @@ ajv@^4.7.0, ajv@^4.9.1:
     json-stable-stringify "^1.0.1"
 
 ajv@^5.0.0:
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.1.5.tgz#8734931b601f00d4feef7c65738d77d1b65d1f68"
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.0.tgz#c1735024c5da2ef75cc190713073d44f098bf486"
   dependencies:
     co "^4.6.0"
+    fast-deep-equal "^0.1.0"
+    json-schema-traverse "^0.3.0"
     json-stable-stringify "^1.0.1"
 
 align-text@^0.1.1, align-text@^0.1.3:
@@ -1548,12 +1550,12 @@ caniuse-api@^1.5.2, caniuse-api@^1.5.3:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000187, caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000684"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000684.tgz#99acb0118b8fd1fdd601a15e0c0f2dfc15a81680"
+  version "1.0.30000686"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000686.tgz#d55b479ed6e6402c1fd3f1fd8f46e694d86ea464"
 
 caniuse-lite@^1.0.30000670, caniuse-lite@^1.0.30000684:
-  version "1.0.30000684"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000684.tgz#0c1032d0b36e14d1ac199f93ef2d1c42d3f03fd7"
+  version "1.0.30000686"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000686.tgz#d9d9ec6110e5533be544a689003f7596532c67d3"
 
 case-sensitive-paths-webpack-plugin@^2.0.0:
   version "2.1.1"
@@ -2891,6 +2893,10 @@ extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
 
+fast-deep-equal@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-0.1.0.tgz#5c6f4599aba6b333ee3342e2ed978672f1001f8d"
+
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
@@ -3153,8 +3159,8 @@ function-bind@^1.0.2, function-bind@^1.1.0:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
 fuse.js@^3.0.1:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.0.4.tgz#cd4e2ec63ac324e28f5d17fcc3d01584379d3717"
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.0.5.tgz#b58d85878802321de94461654947b93af1086727"
 
 fuzzysearch@^1.0.3:
   version "1.0.3"
@@ -3233,7 +3239,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@7.1.1:
+glob@7.1.1, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -3241,17 +3247,6 @@ glob@7.1.1:
     inflight "^1.0.4"
     inherits "2"
     minimatch "^3.0.2"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -3446,8 +3441,8 @@ html-entities@^1.2.0:
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
 
 html-tags@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-1.1.1.tgz#869f43859f12d9bdc3892419e494a628aa1b204e"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-1.2.0.tgz#c78de65b5663aa597989dd2b7ab49200d7e4db98"
 
 http-errors@~1.6.1:
   version "1.6.1"
@@ -4284,6 +4279,10 @@ json-loader@^0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.4.tgz#8baa1365a632f58a3c46d20175fc6002c96e37de"
 
+json-schema-traverse@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.0.tgz#0016c0b1ca1efe46d44d37541bcdfc19dcfae0db"
+
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
@@ -4599,7 +4598,7 @@ lodash@4.17.2:
   version "4.17.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.2.tgz#34a3055babe04ce42467b607d700072c7ff6bf42"
 
-lodash@4.x.x, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.0, lodash@^4.11.2, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.2:
+lodash@4.17.4, lodash@4.x.x, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.0, lodash@^4.11.2, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.2:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -4793,7 +4792,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
 
-minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
+minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -5166,8 +5165,8 @@ ora@^0.2.3:
     object-assign "^4.0.1"
 
 ora@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/ora/-/ora-1.2.0.tgz#32fb3183500efe83f5ea89101785f0ee6060fec9"
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-1.3.0.tgz#80078dd2b92a934af66a3ad72a5b910694ede51a"
   dependencies:
     chalk "^1.1.1"
     cli-cursor "^2.1.0"
@@ -6054,8 +6053,8 @@ progress@^1.1.8:
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
 promise@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.0.tgz#e7feec5aa87a2cbb81acf47d9a3adbd9d4642d7b"
   dependencies:
     asap "~2.0.3"
 
@@ -6190,8 +6189,8 @@ react-datetime@^2.8.10:
     react-onclickoutside "^5.9.0"
 
 react-docgen@^2.15.0:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-2.15.0.tgz#11aced462256e4862b14e6af6e46bdcefacb28bb"
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-2.16.0.tgz#03c9eba935de8031d791ab62657b7b6606ec5da6"
   dependencies:
     async "^2.1.4"
     babel-runtime "^6.9.2"
@@ -6200,6 +6199,10 @@ react-docgen@^2.15.0:
     doctrine "^2.0.0"
     node-dir "^0.1.10"
     recast "^0.11.5"
+
+react-dom-factories@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-dom-factories/-/react-dom-factories-1.0.0.tgz#f43c05e5051b304f33251618d5bc859b29e46b6d"
 
 react-dom@15.5.4:
   version "15.5.4"
@@ -6257,14 +6260,15 @@ react-komposer@^2.0.0:
     shallowequal "^0.2.2"
 
 react-modal@^1.7.6, react-modal@^1.7.7:
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-1.9.4.tgz#f6823c29ca9ecbecd9cc2a9f019e78e4319bafdd"
+  version "1.9.7"
+  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-1.9.7.tgz#07ef56790b953e3b98ef1e2989e347983c72871d"
   dependencies:
     create-react-class "^15.5.2"
     element-class "^0.2.0"
     exenv "1.2.0"
     lodash.assign "^4.2.0"
     prop-types "^15.5.7"
+    react-dom-factories "^1.0.0"
 
 react-onclickoutside@^5.9.0:
   version "5.11.1"
@@ -6453,13 +6457,13 @@ reduce-function-call@^1.0.1:
     balanced-match "^0.4.2"
 
 redux@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/redux/-/redux-3.6.0.tgz#887c2b3d0b9bd86eca2be70571c27654c19e188d"
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.0.tgz#07a623cafd92eee8abe309d13d16538f6707926f"
   dependencies:
     lodash "^4.2.1"
     lodash-es "^4.2.1"
     loose-envify "^1.1.0"
-    symbol-observable "^1.0.2"
+    symbol-observable "^1.0.3"
 
 regenerate@^1.2.1:
   version "1.3.2"
@@ -6718,8 +6722,8 @@ rx@^4.1.0:
   resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
 
 rxjs@^5.0.0-beta.11:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.4.0.tgz#a7db14ab157f9d7aac6a56e655e7a3860d39bf26"
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.4.1.tgz#b62f757f279445d265a18a58fb0a70dc90e91626"
   dependencies:
     symbol-observable "^1.0.1"
 
@@ -7270,7 +7274,7 @@ svgo@^0.7.0:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
-symbol-observable@^1.0.1, symbol-observable@^1.0.2:
+symbol-observable@^1.0.1, symbol-observable@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
@@ -7566,8 +7570,8 @@ utils-merge@1.0.0:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
 
 uuid@^3.0.0, uuid@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Replace custom built utils functions for equivalent lodash methods.

These changes will require some extra setup work when generating the build to ensure
only the methods used are included in the bundle

Closes https://github.com/obartra/reflex/issues/69