### PR TITLE
ci(performance): Run tests in parallel

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,10 +15,9 @@ dependencies:
   post:
     - yarn build
 test:
-  pre:
-    - yarn lint
   override:
-    - yarn test
+    - scripts/citests.sh:
+        parallel: true
 deployment:
   publish:
     owner: obartra

--- a/scripts/citests.sh
+++ b/scripts/citests.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+#
+# Splits test stage tasks between different CircleCI Nodes to improve performance.
+#
+
+echo "Running node $CIRCLE_NODE_INDEX"
+
+if [ "$CIRCLE_NODE_INDEX" -eq "0" ]; then
+  yarn lint       # Run linting tasks
+  yarn test:unit  # Run unit tests
+else
+  yarn test:image # Run image comparison tests
+fi


### PR DESCRIPTION
Split testing into 2 nodes to increase performance. Currently the biggest bottleneck is the image
comparison tests. This will allow running them while checking linting and unit tests. It should
speed things up by ~1 minute

Closes https://github.com/obartra/reflex/issues/95