### PR TITLE
fix(fonts): Correct deployed font load

### DIFF
--- a/stories/core/variables.css
+++ b/stories/core/variables.css
@@ -7,7 +7,8 @@
 
 @font-face {
   font-family: 'Geometria';
-  src: url('/fonts/Geometria-Light.ttf') format('truetype');
+  src: url('https://obartra.github.io/reflex/fonts/Geometria-Light.ttf')
+    format('truetype');
   font-weight: 100;
   font-style: normal;
 }


### PR DESCRIPTION
Top level iframe font was deployed correctly but not the one within iframes.

By setting them to the same font file path we prevent downloading them twice
(inside and outside the iframe)