### PR TITLE
feat(layout): Add report layout

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,8 @@
   },
   "env": {
     "es6": true,
-    "browser": true
+    "browser": true,
+    "jasmine": true
   },
   "plugins": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "flex",
   "version": "1.0.0",
-  "description": "Flexbox-based column layout system",
+  "description": "Flexbox React 12-column layout system",
   "main": "index.js",
   "repository": {
     "type": "git",
@@ -61,8 +61,12 @@
   },
   "jest": {
     "moduleNameMapper": {
-      "^.+\\.(css|txt|md)$": "identity-obj-proxy"
-    }
+      "^.+\\.css$": "identity-obj-proxy",
+      "^.+\\.(md|txt)$": "<rootDir>/test/stringStub.js"
+    },
+    "testMatch": [
+      "**/?(*.)spec.js"
+    ]
   },
   "scripts": {
     "build": "postcss -c scripts/postcss.config.js -o dist/flex.build.css src/index.css",

--- a/src/grid.css
+++ b/src/grid.css
@@ -21,6 +21,10 @@
   padding: 0;
 }
 
+.grid:not(.col) {
+  flex-grow: 1;
+}
+
 .gridMarginNone > .col:not(.margin) {
   padding: 0;
 }

--- a/src/grid.hoc.js
+++ b/src/grid.hoc.js
@@ -10,15 +10,18 @@ import type {
   Offset,
   Size,
 } from './types'
+import Padding from './padding'
 import styles from './index.css'
 
 export type Props = {
   align?: AlignGrid,
+  children?: Element | Array<Element>,
   className?: string,
   justify?: Justify,
   margin: Margin,
   marginSize: MarginSize,
   offset: Offset,
+  padding?: string | void,
   root?: boolean,
   size?: Size,
 }
@@ -48,11 +51,13 @@ export default function Grid(Component: any) {
     render() {
       const {
         align,
+        children,
         className,
         justify,
         margin,
         marginSize,
         offset,
+        padding,
         root,
         size,
         ...props
@@ -74,8 +79,21 @@ export default function Grid(Component: any) {
           '"Grid" (unlike "Item") cannot simultaneously have size and offset'
         )
       }
+      if (padding) {
+        return (
+          <Component {...props} className={classes.join(' ')}>
+            <Padding direction={padding}>
+              {children}
+            </Padding>
+          </Component>
+        )
+      }
 
-      return <Component {...props} className={classes.join(' ')} />
+      return (
+        <Component {...props} className={classes.join(' ')}>
+          {children}
+        </Component>
+      )
     }
 
     static displayName = `withGrid(${getDisplayName(Component)})`

--- a/src/layout.css
+++ b/src/layout.css
@@ -1,17 +1,17 @@
 @import "./variables";
 
-.parent, .auto, .stretch {
+.layout {
+  display: flex;
+  align-self: flex-start;
+  flex-flow: column;
   box-sizing: border-box;
   width: 100%;
   padding: var(--gutter);
 }
 
 .parent {
-  align-items: center;
-  display: flex;
-  flex-flow: column;
   flex-grow: 1;
-  height: 100%;
+  min-height: 100%;
 }
 
 .overflow {

--- a/src/layout.hoc.js
+++ b/src/layout.hoc.js
@@ -37,7 +37,7 @@ function getOverflow(overflow: Overflow): string {
 }
 
 export default function Layout(Component: any) {
-  return class withGrid extends React.PureComponent {
+  return class withLayout extends React.PureComponent {
     props: {
       className?: String,
       fixed?: Fixed,

--- a/src/padding.css
+++ b/src/padding.css
@@ -1,0 +1,22 @@
+@import "./variables.css";
+
+.padding {
+  box-sizing: border-box;
+  width: 100%;
+}
+
+.top {
+  padding-top: var(--gutter);
+}
+
+.right {
+  padding-right: var(--gutter);
+}
+
+.bottom {
+  padding-bottom: var(--gutter);
+}
+
+.left {
+  padding-left: var(--gutter);
+}

--- a/src/padding.js
+++ b/src/padding.js
@@ -1,0 +1,26 @@
+// @flow
+import React from 'react'
+import { compact } from 'lodash'
+import styles from './padding.css'
+import { getSides } from './utils'
+
+export default class Padding extends React.PureComponent {
+  props: {
+    children?: Element | Array<Element>,
+    direction?: string | void,
+  }
+
+  render() {
+    const { direction, children } = this.props
+    const classes = compact([
+      styles.padding,
+      ...getSides(direction).map(dir => styles[dir]),
+    ]).join(' ')
+
+    return (
+      <div className={classes}>
+        {children}
+      </div>
+    )
+  }
+}

--- a/src/types.js
+++ b/src/types.js
@@ -22,6 +22,8 @@ export type Margin = 'none' | 'all' | 'horizontal' | 'vertical' | void
 
 export type MarginSize = 'half' | 'double' | void
 
+export type IndividualSides = 'top' | 'right' | 'bottom' | 'left'
+
 export type Fixed = 'top' | 'bottom' | void
 
 export type Overflow = 'scrollbars' | void

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,7 @@
 // @flow
+import { uniq } from 'lodash'
 import styles from './index.css'
-import type { Component, Margin, MarginSize } from './types'
+import type { Component, Margin, MarginSize, IndividualSides } from './types'
 
 /* eslint-disable no-unused-vars */
 const noop = (...params: any[]) => null
@@ -49,6 +50,27 @@ export function getMargin(
     default:
       return ''
   }
+}
+
+const individualSides = ['top', 'right', 'bottom', 'left']
+const sideMaps = {
+  horizontal: ['right', 'left'],
+  vertical: ['top', 'bottom'],
+  all: individualSides,
+  none: [],
+}
+
+export function getSides(sides?: string = ''): Array<IndividualSides> {
+  const allSides = sides.split(' ').reduce((acc, current) => {
+    if (individualSides.includes(current)) {
+      return [...acc, current]
+    } else if (current in sideMaps) {
+      return [...acc, ...sideMaps[current]]
+    }
+    return acc
+  }, [])
+
+  return uniq(allSides)
 }
 
 /* eslint-disable no-console */

--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -1,0 +1,49 @@
+import { getSides } from './utils'
+
+describe('getSides', () => {
+  it('should not crash when no parameters are passed', () => {
+    expect(getSides()).toEqual([])
+  })
+
+  it('should return an empty array when no sides are set', () => {
+    expect(getSides('')).toEqual([])
+  })
+
+  it('should return an empty array when "none" is set', () => {
+    expect(getSides('none')).toEqual([])
+  })
+
+  it('should convert "all" to all directions', () => {
+    const all = getSides('all')
+
+    expect(all.includes('top')).toBeTruthy()
+    expect(all.includes('right')).toBeTruthy()
+    expect(all.includes('bottom')).toBeTruthy()
+    expect(all.includes('left')).toBeTruthy()
+  })
+
+  it('should convert "vertical" to top/bottom directions', () => {
+    const all = getSides('vertical')
+
+    expect(all.includes('top')).toBeTruthy()
+    expect(all.includes('bottom')).toBeTruthy()
+  })
+
+  it('should convert "horizontal" to left/right directions', () => {
+    const all = getSides('horizontal')
+
+    expect(all.includes('left')).toBeTruthy()
+    expect(all.includes('right')).toBeTruthy()
+  })
+
+  describe('Behavior documented by padding.md', () => {
+    it('should ignore sizes that have less sides than already defined, regardless of order', () => {
+      expect(getSides('none all')).toEqual(getSides('all'))
+      expect(getSides('all none')).toEqual(getSides('all'))
+    })
+
+    it('should treat vertical top the same than vertical)', () => {
+      expect(getSides('vertical top')).toEqual(getSides('vertical'))
+    })
+  })
+})

--- a/stories/core/stories.css
+++ b/stories/core/stories.css
@@ -2,7 +2,7 @@
 
 body {
   margin: 0;
-  padding: 50px 0 0 0;
+  padding: 50px 0;
 }
 
 * {

--- a/stories/grid/autoflow.js
+++ b/stories/grid/autoflow.js
@@ -6,6 +6,7 @@ import { Grid, Layout } from '../../src'
 import { Box, getMarginSelect } from '../core'
 
 export default function() {
+  const items = number('items', 5, { range: true, min: 0, max: 100 })
   const props = {
     align: boolean('Stretch', true) && 'stretch',
     ...getMarginSelect(),
@@ -26,7 +27,7 @@ export default function() {
             height: 100,
           }}
         />
-        {times(number('items', 5, { range: true, min: 0, max: 100 }), index =>
+        {times(items, index =>
           <Box size={2} key={index} type="A" value={`${index + 6}`} />
         )}
       </Grid>

--- a/stories/grid/margin.md
+++ b/stories/grid/margin.md
@@ -3,3 +3,5 @@
 This example allows toggling individual margins as well as global ones (the ones set by the grid).
 
 You can, for instance, define no margins globally but assign margin to a specific element within the Grid.
+
+Changing default margins may result in elements exceeding the grid size. Make sure to check the grid when testing layout changes.

--- a/stories/grid/padding.js
+++ b/stories/grid/padding.js
@@ -1,0 +1,62 @@
+// @flow
+import React from 'react'
+import { Grid, Item } from '../../src'
+import { Root } from '../core'
+import styles from '../core/stories.css'
+
+export default function() {
+  return (
+    <Root>
+      <Grid justify="center">
+        <Item size={12}>
+          <h1>Top Right Padding</h1>
+        </Item>
+        <Grid size={6} className={styles.colors2} padding="top right">
+          <Item size={12} className={styles.colors3}>
+            Content
+          </Item>
+        </Grid>
+      </Grid>
+      <Grid justify="center">
+        <Item size={12}>
+          <h1>All-sides Padding</h1>
+        </Item>
+        <Grid size={6} className={styles.colors2} padding="all">
+          <Item size={12} className={styles.colors3}>
+            Content
+          </Item>
+        </Grid>
+      </Grid>
+      <Grid justify="center">
+        <Item size={12}>
+          <h1>No Padding</h1>
+        </Item>
+        <Grid size={6} className={styles.colors2}>
+          <Item size={12} className={styles.colors3}>
+            Content
+          </Item>
+        </Grid>
+      </Grid>
+      <Grid justify="center">
+        <Item size={12}>
+          <h1>Bottom Padding</h1>
+        </Item>
+        <Grid size={6} className={styles.colors2} padding="bottom">
+          <Item size={12} className={styles.colors3}>
+            Content
+          </Item>
+        </Grid>
+      </Grid>
+      <Grid justify="center">
+        <Item size={12}>
+          <h1>Top-Right-Left Padding</h1>
+        </Item>
+        <Grid size={6} className={styles.colors2} padding="horizontal top">
+          <Item size={12} className={styles.colors3}>
+            Content
+          </Item>
+        </Grid>
+      </Grid>
+    </Root>
+  )
+}

--- a/stories/grid/padding.md
+++ b/stories/grid/padding.md
@@ -1,0 +1,18 @@
+# Padding
+
+Padding can be set for any grid element. Valid values are:
+
+- top
+- right
+- bottom
+- left
+- horizontal
+- vertical
+- all
+- none
+
+Additional sides always take precendence so "none all" is the same than "all".
+
+"vertical top bottom" has no different meaning than just "vertical" since the same sides are affected.
+
+To define all sides but "left", for instance, one could do "top right bottom" or "vertical right"

--- a/stories/grid/verticalAlign.md
+++ b/stories/grid/verticalAlign.md
@@ -1,3 +1,7 @@
 # Vertical Align
 
 Alignment defaults to top but middle and bottom are also available
+
+Note that while `align="top"` has the same behavior than the default, `align="top"` is useful to break inheritance.
+
+For instance, if the parent is set to `align="stretch"`, setting a child to `align="top"` will ensure its children align to the top.

--- a/stories/layout/cards.js
+++ b/stories/layout/cards.js
@@ -25,12 +25,12 @@ export default function() {
           marginSize="half"
         >
           <Grid root margin="horizontal">
-            <Box size={2} type="C" />
-            <Box size={2} type="C" />
-            <Box size={2} type="C" />
-            <Box size={2} type="C" />
-            <Box size={2} type="C" />
-            <Box size={2} type="C" />
+            <Box size={2} type="D" />
+            <Box size={2} type="D" />
+            <Box size={2} type="D" />
+            <Box size={2} type="D" />
+            <Box size={2} type="D" />
+            <Box size={2} type="D" />
           </Grid>
         </Layout>
       </Layout>
@@ -38,7 +38,7 @@ export default function() {
         <Layout type="stretch">
           <Grid root>
             <Grid align="stretch">
-              <Box size={10} type="D" style={SIZE.TALL} />
+              <Box size={10} type="B" style={SIZE.TALL} />
               <Box size={2} type="B" style={SIZE.SMALL} />
               <Box size={12} type="B" style={SIZE.MEDIUM} />
               <Box size={6} type="B" style={SIZE.SMALL} />

--- a/stories/layout/holyGrail.js
+++ b/stories/layout/holyGrail.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react'
 import { boolean } from '@storybook/addon-knobs'
-import { Grid, Layout } from '../../src'
+import { Grid, Item, Layout } from '../../src'
 import { loremIpsum } from '../core'
 import styles from './layout.css'
 
@@ -20,7 +20,9 @@ export default function() {
           <Grid size={2} className={styles.nav}><h2>Nav</h2></Grid>
           <Grid size={8} className={styles.content} align="top">
             <h2>Content</h2>
-            {includeText && <p>{loremIpsum}</p>}
+            <Item size={12}>
+              {includeText && <p>{loremIpsum}</p>}
+            </Item>
           </Grid>
           <Grid size={2} className={styles.ads}><h2>Ads</h2></Grid>
         </Grid>

--- a/stories/layout/report.css
+++ b/stories/layout/report.css
@@ -1,43 +1,29 @@
 @import "../core/variables.css";
 
-.page {
+.report {
   position: absolute;
   top: 0;
 
-  & h1, & h2, & .nav > *, & .ads > * {
-    margin: 10px;
+  & h2 {
+    margin: 0;
   }
 
-  & input, & button {
+  & button {
     width: 100%;
     height: 40px;
     font-size: 18px;
     box-sizing: border-box;
-  }
-
-  & input {
-    outline: 1px solid var(--axonBlack);
-    border: 0;
-  }
-
-  /* header heights, hard coded offsets */
-
-  & .main {
-    margin-top: 57px;
-  }
-
-  &.hasSubheader .main {
-    margin-top: 165px;
-  }
-
-  /* end of hard coded offsets */
-
-  & button {
     border-radius: 0;
     border: 0;
     color: var(--axonBlack);
     background-color: var(--axonGold);
   }
+
+  /* header heights, hard coded offsets */
+  & .content, & .nav, & .clippy {
+    margin-top: 168px;
+  }
+  /* end of hard coded offsets */
 
   & .header, & .footer {
     color: var(--axonGold);
@@ -59,15 +45,41 @@
     background-color: white;
   }
 
-  & .ads {
-    color: var(--axonBlack);
-    background-color: var(--axonGold);
-  }
-
   & .top {
     padding-top: 48px;
     padding-bottom: 48px;
     color: var(--nomuraGray);
     background-color: var(--bolt);
+  }
+
+  & p, & ul, & li {
+    margin: 0;
+    padding: 0;
+  }
+
+  & li {
+    display: block;
+    width: calc(24px * 2);
+    height: calc(24px * 2);
+
+    &:nth-child(2n + 1) {
+      color: var(--axonBlack);
+      background-color: white;
+    }
+
+    &:nth-child(2n) {
+      color: var(--axonGold);
+      background-color: var(--axonBlack);
+    }
+  }
+
+  & .subheader {
+    color: var(--nomuraGray);
+    background-color: var(--bolt);
+  }
+
+  & .nav {
+    background-color: transparent;
+    color: var(--bolt);
   }
 }

--- a/stories/layout/report.js
+++ b/stories/layout/report.js
@@ -1,0 +1,115 @@
+// @flow
+import React from 'react'
+import { Grid, Item, Layout } from '../../src'
+import { Box, loremIpsum } from '../core'
+import { colors1, colors2 } from '../core/stories.css'
+import styles from './report.css'
+
+function P(props) {
+  return (
+    <Item size={12}>
+      <p {...props} />
+    </Item>
+  )
+}
+
+function Card({
+  children,
+  height = 70,
+}: {
+  children?: any,
+  height?: number,
+}): React$Element<any> {
+  return (
+    <Item size={12} style={{ height }}>
+      <div style={{ height: '100%' }} className={styles.card}>
+        <P>{children}</P>
+      </div>
+    </Item>
+  )
+}
+
+export default function() {
+  return (
+    <Layout type="parent" className={styles.report}>
+      <Layout fixed="top">
+        <Layout className={styles.header}>
+          <Grid root>
+            <Item size={12} margin="horizontal"><h1>Header</h1></Item>
+          </Grid>
+        </Layout>
+        <Layout className={styles.subheader} margin="none">
+          <Grid root margin="horizontal">
+            <Item size={12}><h2>Subheader</h2></Item>
+            <Box size={2} type="C" />
+            <Box size={2} type="C" />
+            <Box size={2} type="C" />
+            <Box size={2} type="C" />
+            <Box size={2} offset={2} type="C" />
+          </Grid>
+        </Layout>
+      </Layout>
+      <Layout type="parent" className={`${styles.main} ${colors2}`}>
+        <Layout type="stretch">
+          <Grid root>
+            <Grid align="stretch">
+              <Grid size={1} className={styles.nav} align="top" padding="top">
+                <Item size={12}>
+                  <ul>
+                    <li>Item 1</li>
+                    <li>Item 2</li>
+                    <li>Item 3</li>
+                    <li>Item 4</li>
+                    <li>Item 5</li>
+                    <li>Item 6</li>
+                  </ul>
+                </Item>
+              </Grid>
+              <Grid
+                size={7}
+                className={styles.content}
+                align="top"
+                padding="top"
+              >
+                <P>Text A</P>
+                <Card height={140}>First Block</Card>
+                <Card>Second Block</Card>
+                <P>Text B</P>
+                <Card>Another Block</Card>
+                <P>Text C</P>
+                <Card>Another Block</Card>
+                <P>Text D</P>
+                <Card>Another Block</Card>
+                <P>Text E</P>
+                <Card>Another Block</Card>
+                <P>Text F</P>
+                <Card height={210}>Final Block</Card>
+                <Card>Ok last one</Card>
+                <P>{loremIpsum.substr(0, 250)}...</P>
+              </Grid>
+              <Grid size={4} margin="horizontal">
+                <Grid size={12} className={styles.clippy}>
+                  <Grid
+                    size={12}
+                    align="top"
+                    className={` ${colors1}`}
+                    padding="all"
+                  >
+                    <Item margin="vertical">
+                      Side bar
+                    </Item>
+                  </Grid>
+                </Grid>
+              </Grid>
+            </Grid>
+          </Grid>
+        </Layout>
+        <Layout className={styles.footer}>
+          <Grid root>
+            <h1>Footer</h1>
+          </Grid>
+        </Layout>
+      </Layout>
+    </Layout>
+  )
+}

--- a/stories/layout/report.md
+++ b/stories/layout/report.md
@@ -1,0 +1,3 @@
+# Report
+
+This page features an example page that has sections with different background colors. Because of that, precise margin and padding control is required.

--- a/stories/layout/stack.js
+++ b/stories/layout/stack.js
@@ -10,7 +10,7 @@ function getStaticSection(index) {
   return (
     <Layout key={index}>
       <Grid root>
-        <Grid margin="none">
+        <Grid margin="horizontal">
           <Box size={12} type="C" value={`Section ${index + 1}`} />
         </Grid>
       </Grid>
@@ -21,7 +21,7 @@ function getStaticSection(index) {
 function getContainerSection(index, subsections) {
   return (
     <Layout key={index} type="parent" overflow="scrollbars">
-      <Grid root>
+      <Grid root align="top">
         {times(subsections, i =>
           <Grid key={i}>
             <Item size={12}><h1>SubSection {i + 1}</h1></Item>
@@ -44,7 +44,7 @@ export default function() {
   const sections = number('Sections', 2, { range: true, min: 2, max: 10 })
 
   return (
-    <Layout type="parent" className={style.page}>
+    <Layout type="parent" className={style.page} style={{ maxHeight: '100%' }}>
       {times(sections, index => getSection(index, subSections))}
     </Layout>
   )

--- a/stories/layout/twoSections.js
+++ b/stories/layout/twoSections.js
@@ -29,18 +29,20 @@ export default function() {
           </Grid>
         </Layout>
         <Layout type="stretch">
-          <Grid root>
-            <Grid className={styles.content} align="top">
+          <Grid root className={styles.content}>
+            <Grid align="top">
               <h2>Content</h2>
-              {includeText && <p>{loremIpsum}</p>}
+              <Item size={12}>
+                {includeText && <p>{loremIpsum}</p>}
+              </Item>
             </Grid>
           </Grid>
         </Layout>
-        <Layout className={styles.footer}>
-          <Grid root>
-            <h1>Footer</h1>
-          </Grid>
-        </Layout>
+      </Layout>
+      <Layout className={styles.footer}>
+        <Grid root>
+          <h1>Footer</h1>
+        </Grid>
       </Layout>
     </Layout>
   )

--- a/storybook/config.js
+++ b/storybook/config.js
@@ -1,3 +1,21 @@
+/* eslint-disable */
+if (
+  typeof window === 'object' &&
+  window.navigator &&
+  /node\.js/i.test(window.navigator.userAgent)
+) {
+  var addons = require('@storybook/addons').default
+  var Channel = require('@storybook/channels').default
+  addons.setChannel(
+    new Channel({
+      transport: {
+        setHandler: function() {},
+        send: function() {},
+      },
+    })
+  )
+}
+
 /* eslint-disable global-require, no-underscore-dangle */
 import { configure, setAddon } from '@storybook/react'
 import JSXAddon from 'storybook-addon-jsx'

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -24,6 +24,7 @@
   li:focus,
   a:focus {
     outline: none;
+    font-weight: 900;
   }
 
   input[type="text"],
@@ -67,5 +68,13 @@
   select:hover {
     outline-offset: 0 !important;
     outline-width: 2px !important;
+  }
+
+  .Resizer.vertical {
+    border-right: 1px solid #1D1F21;
+  }
+
+  .Resizer.horizontal {
+    border-top: 1px solid #1D1F21;
   }
 </style>

--- a/test/__snapshots__/Storyshots.spec.js.snap
+++ b/test/__snapshots__/Storyshots.spec.js.snap
@@ -2076,6 +2076,137 @@ exports[`Storyshots Grid Offset 1`] = `
 </div>
 `;
 
+exports[`Storyshots Grid Padding 1`] = `
+<div>
+  <div>
+    <div
+      className="parent layoutMarginNone layout"
+    >
+      <div
+        className="gridRoot grid"
+      >
+        <div
+          className="gridCenter grid"
+        >
+          <div
+            className="col col-12"
+          >
+            <h1>
+              Top Right Padding
+            </h1>
+          </div>
+          <div
+            className="colors2 col-6 col grid"
+          >
+            <div
+              className="padding top right"
+            >
+              <div
+                className="colors3 col col-12"
+              >
+                Content
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="gridCenter grid"
+        >
+          <div
+            className="col col-12"
+          >
+            <h1>
+              All-sides Padding
+            </h1>
+          </div>
+          <div
+            className="colors2 col-6 col grid"
+          >
+            <div
+              className="padding top right bottom left"
+            >
+              <div
+                className="colors3 col col-12"
+              >
+                Content
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="gridCenter grid"
+        >
+          <div
+            className="col col-12"
+          >
+            <h1>
+              No Padding
+            </h1>
+          </div>
+          <div
+            className="colors2 col-6 col grid"
+          >
+            <div
+              className="colors3 col col-12"
+            >
+              Content
+            </div>
+          </div>
+        </div>
+        <div
+          className="gridCenter grid"
+        >
+          <div
+            className="col col-12"
+          >
+            <h1>
+              Bottom Padding
+            </h1>
+          </div>
+          <div
+            className="colors2 col-6 col grid"
+          >
+            <div
+              className="padding bottom"
+            >
+              <div
+                className="colors3 col col-12"
+              >
+                Content
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="gridCenter grid"
+        >
+          <div
+            className="col col-12"
+          >
+            <h1>
+              Top-Right-Left Padding
+            </h1>
+          </div>
+          <div
+            className="colors2 col-6 col grid"
+          >
+            <div
+              className="padding right left top"
+            >
+              <div
+                className="colors3 col col-12"
+              >
+                Content
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Grid Sizing 1`] = `
 <div>
   <div>
@@ -2759,13 +2890,13 @@ exports[`Storyshots Layout Cards 1`] = `
               className="col col-2"
             >
               <div
-                className="box3"
+                className="box4"
                 style={undefined}
               >
                 <div
                   className="gridMiddle gridCenter grid"
                 >
-                  C
+                  D
                 </div>
               </div>
             </div>
@@ -2773,13 +2904,13 @@ exports[`Storyshots Layout Cards 1`] = `
               className="col col-2"
             >
               <div
-                className="box3"
+                className="box4"
                 style={undefined}
               >
                 <div
                   className="gridMiddle gridCenter grid"
                 >
-                  C
+                  D
                 </div>
               </div>
             </div>
@@ -2787,13 +2918,13 @@ exports[`Storyshots Layout Cards 1`] = `
               className="col col-2"
             >
               <div
-                className="box3"
+                className="box4"
                 style={undefined}
               >
                 <div
                   className="gridMiddle gridCenter grid"
                 >
-                  C
+                  D
                 </div>
               </div>
             </div>
@@ -2801,13 +2932,13 @@ exports[`Storyshots Layout Cards 1`] = `
               className="col col-2"
             >
               <div
-                className="box3"
+                className="box4"
                 style={undefined}
               >
                 <div
                   className="gridMiddle gridCenter grid"
                 >
-                  C
+                  D
                 </div>
               </div>
             </div>
@@ -2815,13 +2946,13 @@ exports[`Storyshots Layout Cards 1`] = `
               className="col col-2"
             >
               <div
-                className="box3"
+                className="box4"
                 style={undefined}
               >
                 <div
                   className="gridMiddle gridCenter grid"
                 >
-                  C
+                  D
                 </div>
               </div>
             </div>
@@ -2829,13 +2960,13 @@ exports[`Storyshots Layout Cards 1`] = `
               className="col col-2"
             >
               <div
-                className="box3"
+                className="box4"
                 style={undefined}
               >
                 <div
                   className="gridMiddle gridCenter grid"
                 >
-                  C
+                  D
                 </div>
               </div>
             </div>
@@ -2858,7 +2989,7 @@ exports[`Storyshots Layout Cards 1`] = `
                 className="col col-10"
               >
                 <div
-                  className="box4"
+                  className="box2"
                   style={
                     Object {
                       "height": 200,
@@ -2868,7 +2999,7 @@ exports[`Storyshots Layout Cards 1`] = `
                   <div
                     className="gridMiddle gridCenter grid"
                   >
-                    D
+                    B
                   </div>
                 </div>
               </div>
@@ -3096,6 +3227,9 @@ exports[`Storyshots Layout Holy Grail 1`] = `
             <h2>
               Content
             </h2>
+            <div
+              className="col col-12"
+            />
           </div>
           <div
             className="ads col-2 col grid"
@@ -3122,11 +3256,469 @@ exports[`Storyshots Layout Holy Grail 1`] = `
 </div>
 `;
 
+exports[`Storyshots Layout Report 1`] = `
+<div>
+  <div>
+    <div
+      className="report parent layoutMarginNone layout"
+    >
+      <div
+        className="fixedTop auto layoutMarginNone layout"
+      >
+        <div
+          className="header auto layoutMarginNone layout"
+        >
+          <div
+            className="gridRoot grid"
+          >
+            <div
+              className="colMarginHorizontal margin col col-12"
+            >
+              <h1>
+                Header
+              </h1>
+            </div>
+          </div>
+        </div>
+        <div
+          className="subheader auto layoutMarginNone layout"
+        >
+          <div
+            className="gridMarginHorizontal gridRoot grid"
+          >
+            <div
+              className="col col-12"
+            >
+              <h2>
+                Subheader
+              </h2>
+            </div>
+            <div
+              className="col col-2"
+            >
+              <div
+                className="box3"
+                style={undefined}
+              >
+                <div
+                  className="gridMiddle gridCenter grid"
+                >
+                  C
+                </div>
+              </div>
+            </div>
+            <div
+              className="col col-2"
+            >
+              <div
+                className="box3"
+                style={undefined}
+              >
+                <div
+                  className="gridMiddle gridCenter grid"
+                >
+                  C
+                </div>
+              </div>
+            </div>
+            <div
+              className="col col-2"
+            >
+              <div
+                className="box3"
+                style={undefined}
+              >
+                <div
+                  className="gridMiddle gridCenter grid"
+                >
+                  C
+                </div>
+              </div>
+            </div>
+            <div
+              className="col col-2"
+            >
+              <div
+                className="box3"
+                style={undefined}
+              >
+                <div
+                  className="gridMiddle gridCenter grid"
+                >
+                  C
+                </div>
+              </div>
+            </div>
+            <div
+              className="colOffset-2 col col-2"
+            >
+              <div
+                className="box3"
+                style={undefined}
+              >
+                <div
+                  className="gridMiddle gridCenter grid"
+                >
+                  C
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="main colors2 parent layoutMarginNone layout"
+      >
+        <div
+          className="stretch layoutMarginNone layout"
+        >
+          <div
+            className="gridRoot grid"
+          >
+            <div
+              className="gridStretch grid"
+            >
+              <div
+                className="gridTop nav col-1 col grid"
+              >
+                <div
+                  className="padding top"
+                >
+                  <div
+                    className="col col-12"
+                  >
+                    <ul>
+                      <li>
+                        Item 1
+                      </li>
+                      <li>
+                        Item 2
+                      </li>
+                      <li>
+                        Item 3
+                      </li>
+                      <li>
+                        Item 4
+                      </li>
+                      <li>
+                        Item 5
+                      </li>
+                      <li>
+                        Item 6
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="gridTop content col-7 col grid"
+              >
+                <div
+                  className="padding top"
+                >
+                  <div
+                    className="col col-12"
+                  >
+                    <p>
+                      Text A
+                    </p>
+                  </div>
+                  <div
+                    className="col col-12"
+                    style={
+                      Object {
+                        "height": 140,
+                      }
+                    }
+                  >
+                    <div
+                      className="card"
+                      style={
+                        Object {
+                          "height": "100%",
+                        }
+                      }
+                    >
+                      <div
+                        className="col col-12"
+                      >
+                        <p>
+                          First Block
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="col col-12"
+                    style={
+                      Object {
+                        "height": 70,
+                      }
+                    }
+                  >
+                    <div
+                      className="card"
+                      style={
+                        Object {
+                          "height": "100%",
+                        }
+                      }
+                    >
+                      <div
+                        className="col col-12"
+                      >
+                        <p>
+                          Second Block
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="col col-12"
+                  >
+                    <p>
+                      Text B
+                    </p>
+                  </div>
+                  <div
+                    className="col col-12"
+                    style={
+                      Object {
+                        "height": 70,
+                      }
+                    }
+                  >
+                    <div
+                      className="card"
+                      style={
+                        Object {
+                          "height": "100%",
+                        }
+                      }
+                    >
+                      <div
+                        className="col col-12"
+                      >
+                        <p>
+                          Another Block
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="col col-12"
+                  >
+                    <p>
+                      Text C
+                    </p>
+                  </div>
+                  <div
+                    className="col col-12"
+                    style={
+                      Object {
+                        "height": 70,
+                      }
+                    }
+                  >
+                    <div
+                      className="card"
+                      style={
+                        Object {
+                          "height": "100%",
+                        }
+                      }
+                    >
+                      <div
+                        className="col col-12"
+                      >
+                        <p>
+                          Another Block
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="col col-12"
+                  >
+                    <p>
+                      Text D
+                    </p>
+                  </div>
+                  <div
+                    className="col col-12"
+                    style={
+                      Object {
+                        "height": 70,
+                      }
+                    }
+                  >
+                    <div
+                      className="card"
+                      style={
+                        Object {
+                          "height": "100%",
+                        }
+                      }
+                    >
+                      <div
+                        className="col col-12"
+                      >
+                        <p>
+                          Another Block
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="col col-12"
+                  >
+                    <p>
+                      Text E
+                    </p>
+                  </div>
+                  <div
+                    className="col col-12"
+                    style={
+                      Object {
+                        "height": 70,
+                      }
+                    }
+                  >
+                    <div
+                      className="card"
+                      style={
+                        Object {
+                          "height": "100%",
+                        }
+                      }
+                    >
+                      <div
+                        className="col col-12"
+                      >
+                        <p>
+                          Another Block
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="col col-12"
+                  >
+                    <p>
+                      Text F
+                    </p>
+                  </div>
+                  <div
+                    className="col col-12"
+                    style={
+                      Object {
+                        "height": 210,
+                      }
+                    }
+                  >
+                    <div
+                      className="card"
+                      style={
+                        Object {
+                          "height": "100%",
+                        }
+                      }
+                    >
+                      <div
+                        className="col col-12"
+                      >
+                        <p>
+                          Final Block
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="col col-12"
+                    style={
+                      Object {
+                        "height": 70,
+                      }
+                    }
+                  >
+                    <div
+                      className="card"
+                      style={
+                        Object {
+                          "height": "100%",
+                        }
+                      }
+                    >
+                      <div
+                        className="col col-12"
+                      >
+                        <p>
+                          Ok last one
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="col col-12"
+                  >
+                    <p>
+                      test-file-stub
+                      ...
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="gridMarginHorizontal col-4 col grid"
+              >
+                <div
+                  className="clippy col-12 col grid"
+                >
+                  <div
+                    className="gridTop  colors1 col-12 col grid"
+                  >
+                    <div
+                      className="padding top right bottom left"
+                    >
+                      <div
+                        className="colMarginVertical margin col colAuto"
+                      >
+                        Side bar
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="footer auto layoutMarginNone layout"
+        >
+          <div
+            className="gridRoot grid"
+          >
+            <h1>
+              Footer
+            </h1>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Layout Stack 1`] = `
 <div>
   <div>
     <div
       className="page parent layoutMarginNone layout"
+      style={
+        Object {
+          "maxHeight": "100%",
+        }
+      }
     >
       <div
         className="auto layoutMarginNone layout"
@@ -3135,7 +3727,7 @@ exports[`Storyshots Layout Stack 1`] = `
           className="gridRoot grid"
         >
           <div
-            className="gridMarginNone grid"
+            className="gridMarginHorizontal grid"
           >
             <div
               className="col col-12"
@@ -3158,7 +3750,7 @@ exports[`Storyshots Layout Stack 1`] = `
         className="parent layoutMarginNone overflow layout"
       >
         <div
-          className="gridRoot grid"
+          className="gridTop gridRoot grid"
         >
           <div
             className="grid"
@@ -3254,27 +3846,30 @@ exports[`Storyshots Layout Two Sections 1`] = `
           className="stretch layoutMarginNone layout"
         >
           <div
-            className="gridRoot grid"
+            className="content gridRoot grid"
           >
             <div
-              className="gridTop content grid"
+              className="gridTop grid"
             >
               <h2>
                 Content
               </h2>
+              <div
+                className="col col-12"
+              />
             </div>
           </div>
         </div>
+      </div>
+      <div
+        className="footer auto layoutMarginNone layout"
+      >
         <div
-          className="footer auto layoutMarginNone layout"
+          className="gridRoot grid"
         >
-          <div
-            className="gridRoot grid"
-          >
-            <h1>
-              Footer
-            </h1>
-          </div>
+          <h1>
+            Footer
+          </h1>
         </div>
       </div>
     </div>


### PR DESCRIPTION
- Add padding option to all grids
- Add padding examples
- Add report example

TODO

- Update margin options to use `getSides` for all components
- Polish report example
  - Sticky navigation (https://github.com/obartra/reflex/issues/103)
  - Tabs should not adhere to the grid but to have an option to size to the min size of the content (https://github.com/obartra/reflex/issues/104)
  - Option to increase the separation between items while respecting page margins
Live version available here: https://obartra.github.io/reflex/branch/report (https://github.com/obartra/reflex/issues/105)

![image](https://user-images.githubusercontent.com/3877773/27396228-47822876-5667-11e7-92cb-aecc19a27a54.png)
