### PR TITLE
fix(deploy): Install before deploy

### DIFF
--- a/scripts/deploynpm.sh
+++ b/scripts/deploynpm.sh
@@ -2,8 +2,10 @@
 
 set -e
 
-yarn build
 echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
+
+yarn
+yarn build
 
 # It will fail if the same version is deployed (e.g. readme changes won't up the version).
 # It should fail because we don't want to redeploy in that case so we just hide the error


### PR DESCRIPTION
Because we publish to gh-pages before deploying to npm, we need to re-run
yarn since we deleted all files in the branch.