### PR TITLE
refactor(npm): Rename package

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Flexbox React 12-column layout system
 To get the library that exports `Item`, `Grid` and `Layout`, run:
 
 ```bash
-yarn add @obartra/reflex
+yarn add xn-reflex
 
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@obartra/reflex",
+  "name": "xn-reflex",
   "version": "0.0.0-semantically-released",
   "description": "Flexbox React 12-column layout system",
   "module": "src/index.js",


### PR DESCRIPTION
Using `xn-reflex` since that one is not taken