### PR TITLE
ci(deploy): Fix deploy errors

### DIFF
--- a/scripts/deploystorybook.sh
+++ b/scripts/deploystorybook.sh
@@ -13,7 +13,8 @@ set -e
 #
 
 # Skip if not on CI
-if [ "$CI" != true ] ; then
+
+if [ "$CI" != true ] || [ "$CIRCLE_NODE_INDEX" -gt "0" ] ; then
   echo "This script is only meant to run on CI. Set 'CI' global to true to override."
   exit 1
 fi

--- a/scripts/deploystorybook.sh
+++ b/scripts/deploystorybook.sh
@@ -14,9 +14,14 @@ set -e
 
 # Skip if not on CI
 
-if [ "$CI" != true ] || [ "$CIRCLE_NODE_INDEX" -gt "0" ] ; then
+if [ "$CI" != true ]; then
   echo "This script is only meant to run on CI. Set 'CI' global to true to override."
   exit 1
+fi
+
+if [ "$CIRCLE_NODE_INDEX" -gt "0" ]; then
+  echo "This script runs on the first CI node. Skipping to prevent multiple deploys to gh-pages"
+  exit 0
 fi
 
 # Ensure all required variables are defined
@@ -77,5 +82,5 @@ else
   git commit -m "docs(storybook): $USER updated '$TARGET_URL'" --no-verify
   git fetch origin gh-pages
   git rebase origin/gh-pages
-  git push -f origin gh-pages
+  git push origin gh-pages
 fi


### PR DESCRIPTION
CI would fail to deploy to gh-pages because both containers were trying to update them at the same
time. This script encofrces deploy storybook to only occur on node 0