### PR TITLE
refactor(stories): Redefine `dropEnds` method

### DIFF
--- a/storybook/shared/storyFolders.js
+++ b/storybook/shared/storyFolders.js
@@ -1,10 +1,11 @@
 // @flow
 
-import { fromPairs, initial, tail, set } from 'lodash'
+import { fromPairs, flow, initial, tail, set } from 'lodash'
 import { readdirSync, lstatSync } from 'fs'
 import { join } from 'path'
 import { getName } from './getName'
 
+const dropEnds = flow(tail, initial)
 const isTest =
   process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'test:image'
 
@@ -30,10 +31,6 @@ function getFilesAndFolders(
 
 function getImagePath(filepath) {
   return filepath.replace(/\.js$/, '.spec.png')
-}
-
-function dropEnds(array) {
-  return tail(initial(array))
 }
 
 function getNote(files, filepath, loader) {

--- a/storybook/stories/components/search/results.js
+++ b/storybook/stories/components/search/results.js
@@ -32,8 +32,8 @@ export default function SearchResults({
           </Grid>
         </Col>
       </Grid>
-      {new Array(results).fill(0).map(() =>
-        <Grid>
+      {times(results, key =>
+        <Grid key={key}>
           <Col size={5}>
             <Grid margin={[0, 0, 0.5, 0]} dev={1}>
               Orci tempus venenatis
@@ -68,7 +68,7 @@ export default function SearchResults({
         </Col>
         <Col marginBottom={0} size={4} align="center">
           {times(pages, num =>
-            <Col marginBottom={0} size="auto">
+            <Col marginBottom={0} size="auto" key={num}>
               {num + 1}
             </Col>
           )}


### PR DESCRIPTION
Replace unnecessary function with `flow` composition as suggested here:

https://github.com/obartra/reflex/pull/145#discussion_r125089019

Also remove test warning for missing `key`s