### PR TITLE
fix(dev): Improve overlay grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 [![CircleCI](https://circleci.com/gh/obartra/reflex/tree/master.svg?style=shield)](https://circleci.com/gh/obartra/reflex/tree/master)
 [![Test Coverage](https://codeclimate.com/github/obartra/reflex/badges/coverage.svg)](https://codeclimate.com/github/obartra/reflex/coverage)
-[![Join the chat at https://gitter.im/react-reflex/Lobby](https://badges.gitter.im/react-reflex/Lobby.svg)](https://gitter.im/react-reflex/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=shield)](http://makeapullrequest.com)
+
+[![Join the chat at https://gitter.im/react-reflex/Lobby](https://badges.gitter.im/react-reflex/Lobby.svg)](https://gitter.im/react-reflex/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Flexbox React 12-column layout system
 

--- a/storybook/shared/designGrid.css
+++ b/storybook/shared/designGrid.css
@@ -1,4 +1,4 @@
-@import "../../src/variables";
+@import "../../src/variables.css";
 @import "./variables.css";
 
 :root {
@@ -31,7 +31,8 @@
   );
   background-size: calc(var(--colWidth) + var(--gutter)) 1px;
 
-  &:before, &:after {
+  &:before,
+  &:after {
     position: absolute;
     content: '';
     top: 0;
@@ -53,11 +54,14 @@
 @media (max-width: 1224px) {
   .contentArea {
     width: var(--smallPageWidth);
-    background-image: linear-gradient(
+    min-width: 400px;
+    background-image: repeating-linear-gradient(
       90deg,
+      transparent,
       transparent var(--col),
-      color(var(--bolt) alpha(0.1)) var(--gutter)
+      color(var(--axonGold) alpha(0.1)) calc(var(--col) + 1px),
+      color(var(--axonGold) alpha(0.1)) calc(var(--col) + var(--gutter) + 2px)
     );
-    background-size: calc(var(--col) + var(--gutter)) 1px;
+    background-size: calc(var(--col) + var(--gutter) + 2px) 1px;
   }
 }


### PR DESCRIPTION
- Fix a bug where column width wasn't computed correctly
- Chrome re-renders the gradient background less often than the actual content
  which results in inconsistencies when the page is smaller than the max content
  size (1224px), after that the content doesn't vary (it's just centered) so
  Chrome renders the right background grid.
- To show the design grid but discourage usage, when the window width is less than
  1224px, the grid is shown in yellow (which makes it harder to view the edges)
- The Chrome issue can be seen by slowly resizing the window width. At specific pixel sizes it works as expected but then falls behind until the next change (~10px intervals)

Closes https://github.com/obartra/reflex/issues/100