### PR TITLE
docs(readme): Better explain reflex usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,42 @@
-# ☁️ Reflex
+# ☁️ [Reflex](https://obartra.github.io/reflex) &middot; [![CircleCI](https://circleci.com/gh/obartra/reflex/tree/master.svg?style=shield)](https://circleci.com/gh/obartra/reflex/tree/master) [![Test Coverage](https://codeclimate.com/github/obartra/reflex/badges/coverage.svg)](https://codeclimate.com/github/obartra/reflex/coverage) [![npm](https://img.shields.io/npm/v/xn-reflex.svg)](https://www.npmjs.com/package/xn-reflex) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=shield)](http://makeapullrequest.com)
 
-[![CircleCI](https://circleci.com/gh/obartra/reflex/tree/master.svg?style=shield)](https://circleci.com/gh/obartra/reflex/tree/master)
-[![Test Coverage](https://codeclimate.com/github/obartra/reflex/badges/coverage.svg)](https://codeclimate.com/github/obartra/reflex/coverage)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=shield)](http://makeapullrequest.com)
+Reflex is a React and flexbox-based layout solution. With Reflex, you can eliminate your layout css or reduce it to just a few lines.
 
-[![Join the chat at https://gitter.im/react-reflex/Lobby](https://badges.gitter.im/react-reflex/Lobby.svg)](https://gitter.im/react-reflex/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[Learn how to use Reflex in your own project](https://github.com/obartra/reflex/wiki/Getting-Started).
 
-Flexbox React 12-column layout system
+## 📺 Examples
 
-**[View the docs here](https://github.com/obartra/reflex/wiki/Usage)**
+We have several examples [on the website](https://obartra.github.io/reflex). Here is one of them:
 
-[Storybook Demo](https://obartra.github.io/reflex)
+```jsx
+import { Grid, Layout } from 'xn-reflex'
+
+<Layout dev={1} fixed="top">
+  <Grid margin={[0, 1]} padding={[0, 1]}>
+    Content here
+  </Grid>
+</Layout>
+```
+
+This example will add a fixed section with the text "Content here" on the page.
+
+The `Layout` Component defines sections in the page that have full width. `Grid` is used for the 12-column layout. We recommend checking the examples [here](https://obartra.github.io/reflex) and following the [Getting Started](https://github.com/obartra/reflex/wiki/Getting-Started) guide for more information.
 
 ## 🖥 Install
 
-To get the library, run:
+Reflex is available as the `xn-reflex` package on [npm](https://www.npmjs.com/). It is also available on the [unpkg CDN](https://unpkg.com/xn-reflex).
+
+You can install it with:
 
 ```bash
 yarn add xn-reflex
-
 ```
 
-Note that `React` and `PropTypes` are dependencies of the generated bundle.
+`React` and `PropTypes` are dependencies of the generated bundle.
 
 ## 👥 Contributors
 
-Check [contributing.md](./CONTRIBUTING.md) for more information.
+The main purpose of this repository is to continue to evolve Reflex, making it more capable and easier to use. Development of Reflex happens in the open on GitHub, and we are grateful to the community for contributing bugfixes and improvements. Check the [contributing.md](./CONTRIBUTING.md) to learn how you can take part in improving Reflex.
 
 Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds/all-contributors#emoji-key)):
 
@@ -40,6 +51,7 @@ This project follows the [all-contributors](https://github.com/kentcdodds/all-co
 
 | Process       | Status    |
 |---------------|-----------|
-| Code Quality  | [![CircleCI](https://circleci.com/gh/obartra/reflex/tree/master.svg?style=shield)](https://circleci.com/gh/obartra/reflex/tree/master) [![Test Coverage](https://codeclimate.com/github/obartra/reflex/badges/coverage.svg)](https://codeclimate.com/github/obartra/reflex/coverage) [![Code Climate](https://codeclimate.com/github/obartra/reflex/badges/gpa.svg)](https://codeclimate.com/github/obartra/reflex) [![codebeat badge](https://codebeat.co/badges/d3b5abcd-60b2-4ab3-96b6-b3ab392b789d)](https://codebeat.co/projects/github-com-obartra-reflex-master) |
+| Code Quality  | [![CircleCI](https://circleci.com/gh/obartra/reflex/tree/master.svg?style=shield)](https://circleci.com/gh/obartra/reflex/tree/master) [![Test Coverage](https://codeclimate.com/github/obartra/reflex/badges/coverage.svg)](https://codeclimate.com/github/obartra/reflex/coverage) [![Code Climate](https://codeclimate.com/github/obartra/reflex/badges/gpa.svg)](https://codeclimate.com/github/obartra/reflex) [![codebeat badge](https://codebeat.co/badges/d3b5abcd-60b2-4ab3-96b6-b3ab392b789d)](https://codebeat.co/projects/github-com-obartra-reflex-master) [![Package Quality](http://npm.packagequality.com/shield/xn-reflex.svg)](http://npm.packagequality.com/#?package=xn-reflex) |
 | Versioning    | [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release) [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/) [![npm](https://img.shields.io/npm/v/xn-reflex.svg)](https://www.npmjs.com/package/xn-reflex) |
 | Dependencies  | [![Known Vulnerabilities](https://snyk.io/test/github/obartra/reflex/badge.svg)](https://snyk.io/test/github/obartra/reflex) [![DavidDM](https://david-dm.org/obartra/reflex.svg)](https://david-dm.org/obartra/reflex) [![bitHound Overall Score](https://www.bithound.io/github/obartra/reflex/badges/score.svg)](https://www.bithound.io/github/obartra/reflex) |
+| Questions     | [![Join the chat at https://gitter.im/react-reflex/Lobby](https://badges.gitter.im/react-reflex/Lobby.svg)](https://gitter.im/react-reflex/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) |


### PR DESCRIPTION
[This is how it's rendered](https://github.com/obartra/reflex/blob/be939b7e7932d9f4badc1ad7ee6e70fcf8ffdd7b/README.md)

Update readme to better reflect what Reflex does and how to get started

Most of the changes are shamelessly (and heavily) inspired on [React readme](https://github.com/facebook/react/blob/master/README.md)