### PR TITLE
fix(notes): Ensure link in notes is always added

### DIFF
--- a/storybook/shared/storyFolders.js
+++ b/storybook/shared/storyFolders.js
@@ -44,7 +44,7 @@ function getNote(files, filepath, loader) {
   const hasMd = files.indexOf(mdFile) !== -1
   const url = filepath.replace('./', baseUrl)
   const note = hasMd ? loader(mdFile).default || loader(mdFile) : ''
-  const footer = hasMd ? require('./footer.md') : ''
+  const footer = (require('./footer.md'): string) || ''
 
   return `${note}${footer.replace('[[url]]', url)}`
 }


### PR DESCRIPTION
Footer notes were only added when an existing md file was present.

Changing the logic because we always want the link to the file, regardless of
whether additional information is available or not.

Closes https://github.com/obartra/reflex/issues/165