### PR TITLE
fix(package): Ensure version.js is published

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,14 @@
   "main": "dist/reflex.js",
   "browser": "dist/reflex.js",
   "homepage": "https://obartra.github.io/reflex",
-  "files": ["package.json", "README.md", "LICENSE", "src", "dist"],
+  "files": [
+    "package.json",
+    "README.md",
+    "LICENSE",
+    "src",
+    "dist",
+    "version.js"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/obartra/reflex"
@@ -79,14 +86,19 @@
     "webpack-bundle-analyzer": "2.8.2"
   },
   "lint-staged": {
-    "*.{js,css}": ["format", "git add"]
+    "*.{js,css}": [
+      "format",
+      "git add"
+    ]
   },
   "jest": {
     "moduleNameMapper": {
       "^.+[.]css$": "identity-obj-proxy",
       "^.+[.](md|txt)$": "<rootDir>/test/stringStub.js"
     },
-    "testMatch": ["**/?(*.)spec.js"]
+    "testMatch": [
+      "**/?(*.)spec.js"
+    ]
   },
   "bundlesize": [
     {


### PR DESCRIPTION
This is only relevant if consuming the unminfied source, version.js was not included
as part of the published bunled. Adding to package.json