### PR TITLE
fix(stories): update invalid stories

### DIFF
--- a/src/layout.js
+++ b/src/layout.js
@@ -56,7 +56,7 @@ export default class Layout extends React.Component {
   props: {
     dev?: Dev,
     devMode?: boolean,
-    className?: String,
+    className?: string,
     fixed?: Fixed,
     margin?: Spacing,
     overflow?: Overflow,

--- a/src/types.js
+++ b/src/types.js
@@ -3,7 +3,7 @@ type zeroThroughEleven = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11
 
 export type Offset = zeroThroughEleven | void
 
-export type Size = zeroThroughEleven | 'fit' | 'auto' | void
+export type Size = zeroThroughEleven | 12 | 'fit' | 'auto' | void
 
 export type Component =
   | {

--- a/storybook/stories/api/autoflow.js
+++ b/storybook/stories/api/autoflow.js
@@ -8,7 +8,7 @@ import { Box, RootLayout, getMarginSelect } from '../../shared'
 export default function() {
   const items = number('Items', 5, { range: true, min: 0, max: 100 })
   const props = {
-    align: !boolean('Stretch', true) && 'top',
+    align: !boolean('Stretch', true) ? 'top' : undefined,
   }
   const margin = getMarginSelect()
 

--- a/storybook/stories/api/margin.js
+++ b/storybook/stories/api/margin.js
@@ -11,7 +11,7 @@ export default function() {
     'Yellow Item Margin Size'
   )
   const margin = getMarginSelect('All Items Margins', 'All Items Margin Size')
-  const align = !boolean('Stretch', true) && 'top'
+  const align = !boolean('Stretch', true) ? 'top' : undefined
 
   const getBox = index =>
     <Box

--- a/storybook/stories/api/verticalAlign.js
+++ b/storybook/stories/api/verticalAlign.js
@@ -44,13 +44,21 @@ export default function() {
         <h1>Grid Align</h1>
       </Col>
       <Grid>
-        <Grid size={4} align={!stretch && 'top'} style={{ height }}>
+        <Grid size={4} align={!stretch ? 'top' : undefined} style={{ height }}>
           {times(items, i => <Box key={i} type="C" value="TOP" />)}
         </Grid>
-        <Grid size={4} align={!stretch && 'center'} style={{ height }}>
+        <Grid
+          size={4}
+          align={!stretch ? 'center' : undefined}
+          style={{ height }}
+        >
           {times(items, i => <Box key={i} type="C" value="CENTER" />)}
         </Grid>
-        <Grid size={4} align={!stretch && 'bottom'} style={{ height }}>
+        <Grid
+          size={4}
+          align={!stretch ? 'bottom' : undefined}
+          style={{ height }}
+        >
           {times(items, i => <Box key={i} type="C" value="BOTTOM" />)}
         </Grid>
       </Grid>

--- a/storybook/stories/components/card/filter.js
+++ b/storybook/stories/components/card/filter.js
@@ -42,7 +42,7 @@ export default function() {
         <Col>
           <h1>Filter List</h1>
         </Col>
-        <Grid align="stretch" justify="center">
+        <Grid justify="center">
           <Col size={6}>
             <Grid margin={bottom}>
               <Grid dev={1} padding={xBottom}>

--- a/storybook/stories/components/card/profile.js
+++ b/storybook/stories/components/card/profile.js
@@ -12,7 +12,7 @@ export default function() {
           <h1>User Profile</h1>
         </Col>
 
-        <Grid align="stretch">
+        <Grid>
           <Col size={4}>
             <Grid dev={2}>Full Bleed</Grid>
           </Col>

--- a/storybook/stories/components/header/basic.js
+++ b/storybook/stories/components/header/basic.js
@@ -10,7 +10,7 @@ export default function() {
 
   return (
     <RootLayout>
-      <Grid align="stretch">
+      <Grid>
         <Box size={2} type="A" value="Go Back" />
         <Box size={6} type="A">
           <h2>Page Title</h2>

--- a/storybook/stories/components/search/results.js
+++ b/storybook/stories/components/search/results.js
@@ -9,9 +9,9 @@ export default function SearchResults({
   pages = 4,
   size,
 }: {
-  results: number,
-  pages: number,
-  size: number,
+  results?: number,
+  pages?: number,
+  size?: number,
 }) {
   return (
     <Grid size={size} dev={2} align="top">

--- a/storybook/stories/examples/cards.js
+++ b/storybook/stories/examples/cards.js
@@ -36,7 +36,7 @@ export default function() {
       <Layout type="parent" className={styles.main}>
         <Layout type="stretch">
           <Root>
-            <Grid align="stretch" padding={top}>
+            <Grid padding={top}>
               <Box size={10} type="B" style={SIZE.TALL} />
               <Box size={2} type="B" style={SIZE.SMALL} />
               <Box type="B" style={SIZE.MEDIUM} />

--- a/storybook/stories/examples/report.js
+++ b/storybook/stories/examples/report.js
@@ -89,7 +89,7 @@ export default function() {
       <Layout type="parent" className={`${styles.main} ${colors2}`}>
         <Layout type="stretch">
           <Root>
-            <Grid align="stretch">
+            <Grid>
               <Grid
                 size={1}
                 className={styles.nav}

--- a/test/__snapshots__/Storyshots.spec.js.snap
+++ b/test/__snapshots__/Storyshots.spec.js.snap
@@ -3132,7 +3132,7 @@ exports[`Storyshots  Components Card.Filter 1`] = `
               </h1>
             </div>
             <div
-              className="grid stretchAlign centerJustify"
+              className="grid centerJustify"
             >
               <div
                 className="rightHalfSpacing bottomSingleSpacing leftHalfSpacing col col-6 grid"
@@ -3362,7 +3362,7 @@ exports[`Storyshots  Components Card.Profile 1`] = `
               </h1>
             </div>
             <div
-              className="grid stretchAlign"
+              className="grid"
             >
               <div
                 className="rightHalfSpacing bottomSingleSpacing leftHalfSpacing col col-4 grid"
@@ -3587,7 +3587,7 @@ exports[`Storyshots  Components Header.Basic 1`] = `
           className="grid rightSingleSpacing leftSingleSpacing"
         >
           <div
-            className="grid stretchAlign"
+            className="grid"
           >
             <div
               className="rightHalfSpacing bottomSingleSpacing leftHalfSpacing col col-2 grid"
@@ -4415,7 +4415,7 @@ exports[`Storyshots  Examples Cards 1`] = `
                 className="grid"
               >
                 <div
-                  className="stretchAlign grid topSingleSpacing"
+                  className="grid topSingleSpacing"
                 >
                   <div
                     className="rightHalfSpacing bottomSingleSpacing leftHalfSpacing col col-10 grid"
@@ -4880,7 +4880,7 @@ exports[`Storyshots  Examples Report 1`] = `
               className="grid rightSingleSpacing leftSingleSpacing"
             >
               <div
-                className="grid stretchAlign"
+                className="grid"
               >
                 <div
                   className="rightHalfSpacing leftHalfSpacing nav col col-1 grid"


### PR DESCRIPTION
The babel plugin that converts flow types to prop-types was correctly throwing an error.
However, due to a bug in that babel plugin, information about the invalid prop-types were
being obscured.

There is a PR open for this babel plugin that should correct this issue: https://github.com/brigand/babel-plugin-flow-react-proptypes/pull/116