### PR TITLE
build(csp): Remove eval from bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "npm-run-all": "4.0.2",
     "postcss-cli": "4.1.0",
     "postcss-cssnext": "3.0.0",
+    "postcss-discard-comments": "2.0.4",
     "postcss-for": "2.1.1",
     "postcss-import": "10.0.0",
     "postcss-loader": "2.0.6",

--- a/scripts/postcss.config.js
+++ b/scripts/postcss.config.js
@@ -1,14 +1,18 @@
+const cssComments = require('postcss-discard-comments')
 const cssFor = require('postcss-for')
-const cssNano = require('cssnano')
-const cssNext = require('postcss-cssnext')
-const cssNesting = require('postcss-nesting')
 const cssImport = require('postcss-import')
+const cssNano = require('cssnano')
+const cssNesting = require('postcss-nesting')
+const cssNext = require('postcss-cssnext')
 
 module.exports = {
   plugins: [
     cssImport(),
     cssNesting(),
     cssFor(),
+    cssComments({
+      removeAll: true,
+    }),
     cssNext({
       features: {
         autoprefixer: false,

--- a/scripts/replaceEval.js
+++ b/scripts/replaceEval.js
@@ -1,0 +1,19 @@
+function expressionGlobalPlugin() {
+  this.state.module.addVariable(
+    'global',
+    "(function() { return this; }()) || Function('return this')()"
+  )
+  return false
+}
+
+function parseExpression(parser) {
+  parser.plugin('expression global', expressionGlobalPlugin)
+}
+
+module.exports = () => ({
+  apply(compiler) {
+    compiler.plugin('compilation', (compilation, params) => {
+      params.normalModuleFactory.plugin('parser', parseExpression)
+    })
+  },
+})

--- a/scripts/webpack.config.js
+++ b/scripts/webpack.config.js
@@ -29,6 +29,20 @@ const cssLoaders = [
   },
 ]
 
+function apply(compiler) {
+  compiler.plugin('compilation', (compilation, params) => {
+    params.normalModuleFactory.plugin('parser', parser => {
+      parser.plugin('expression global', function expressionGlobalPlugin() {
+        this.state.module.addVariable(
+          'global',
+          "(function() { return this; }()) || Function('return this')()"
+        )
+        return false
+      })
+    })
+  })
+}
+
 module.exports = {
   entry: resolve(__dirname, '../src/index.js'),
   output: {
@@ -37,16 +51,15 @@ module.exports = {
     library: 'reflex',
     libraryTarget: 'umd',
   },
-  node: {
-    fs: 'empty',
-  },
+  target: 'web',
   plugins: compact([
-    !isProd && new ExtractTextPlugin('reflex.css'),
     new CleanWebpackPlugin([root], {
       root,
       dry: false,
       verbose: false,
     }),
+    !isProd && new ExtractTextPlugin('reflex.css'),
+    { apply },
     new BundleAnalyzerPlugin({
       analyzerMode: 'static',
       reportFilename: 'stats.html',
@@ -65,6 +78,7 @@ module.exports = {
         sourceMap: true,
       }),
   ]),
+  devtool: 'source-map',
   externals: isProd
     ? {
         react: 'react',

--- a/scripts/webpack.config.js
+++ b/scripts/webpack.config.js
@@ -1,6 +1,7 @@
 const { optimize } = require('webpack')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const CleanWebpackPlugin = require('clean-webpack-plugin')
+const replaceEval = require('./replaceEval')
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
 const { resolve } = require('path')
 const { DefinePlugin } = require('webpack')
@@ -29,20 +30,6 @@ const cssLoaders = [
   },
 ]
 
-function apply(compiler) {
-  compiler.plugin('compilation', (compilation, params) => {
-    params.normalModuleFactory.plugin('parser', parser => {
-      parser.plugin('expression global', function expressionGlobalPlugin() {
-        this.state.module.addVariable(
-          'global',
-          "(function() { return this; }()) || Function('return this')()"
-        )
-        return false
-      })
-    })
-  })
-}
-
 module.exports = {
   entry: resolve(__dirname, '../src/index.js'),
   output: {
@@ -59,7 +46,7 @@ module.exports = {
       verbose: false,
     }),
     !isProd && new ExtractTextPlugin('reflex.css'),
-    { apply },
+    replaceEval(),
     new BundleAnalyzerPlugin({
       analyzerMode: 'static',
       reportFilename: 'stats.html',

--- a/yarn.lock
+++ b/yarn.lock
@@ -6968,7 +6968,7 @@ postcss-custom-selectors@^4.0.1:
     postcss "^6.0.1"
     postcss-selector-matches "^3.0.0"
 
-postcss-discard-comments@^2.0.4:
+postcss-discard-comments@2.0.4, postcss-discard-comments@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz#befe89fafd5b3dace5ccce51b76b81514be00e3d"
   dependencies:


### PR DESCRIPTION
- Webpack 2 includes a CSP check which causes an (intended) console error.
- To prevent that (and assume CSP is always enabled) these changes follow
  the same pattern than redux and replace it from the build
- Remove comments from the css minified bundle
- Use a single helper definition for babel instead of including it per file

Closes https://github.com/obartra/reflex/issues/175