### PR TITLE
feat(flow): add flow types to dist

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -32,7 +32,7 @@
           "module-resolver",
           {
             "alias": {
-              "reflex": "./src/index"
+              "reflex": "./src/reflex"
             }
           }
         ]

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,4 +1,5 @@
 [ignore]
+<PROJECT_ROOT>/dist
 .*/node_modules/stylelint/.*
 .*/node_modules/eslint-plugin-jsx-a11y/.*
 .*/node_modules/config-chain/test/broken.json
@@ -10,7 +11,8 @@
 [libs]
 
 [options]
-module.name_mapper='reflex' -> '<PROJECT_ROOT>/dist/reflex.js'
+module.name_mapper='reflex' -> '<PROJECT_ROOT>/src/reflex.js'
+module.name_mapper='.*\(.css\)' -> 'CSSModule'
 module.name_mapper.extension='txt' -> '<PROJECT_ROOT>/test/stringStub.js'
 module.name_mapper.extension='md' -> '<PROJECT_ROOT>/test/stringStub.js'
 module.ignore_non_literal_requires=true

--- a/flow-typed/cssModules.js
+++ b/flow-typed/cssModules.js
@@ -1,0 +1,4 @@
+// @flow
+declare module CSSModule {
+  declare var exports: { [key: string]: string }
+}

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "eslint-plugin-jsx-a11y": "6.0.2",
     "eslint-plugin-react": "7.1.0",
     "extract-text-webpack-plugin": "3.0.0",
-    "flow-bin": "0.49.1",
+    "flow-bin": "0.51.0",
+    "flow-copy-source": "1.2.0",
     "html-loader": "0.4.5",
     "husky": "0.14.3",
     "identity-obj-proxy": "3.0.0",
@@ -117,6 +118,7 @@
   "scripts": {
     "build:dev": "webpack --config scripts/webpack.config.js",
     "build:min": "cross-env NODE_ENV=production webpack --config scripts/webpack.config.js -p",
+    "build:types": "flow-copy-source -v src dist",
     "build": "npm-run-all --parallel build:*",
     "commit": "git-cz",
     "contributors:add": "all-contributors add",

--- a/scripts/webpack.config.js
+++ b/scripts/webpack.config.js
@@ -31,7 +31,7 @@ const cssLoaders = [
 ]
 
 module.exports = {
-  entry: resolve(__dirname, '../src/index.js'),
+  entry: resolve(__dirname, '../src/reflex.js'),
   output: {
     path: root,
     filename: isProd ? 'reflex.min.js' : 'reflex.js',

--- a/src/reflex.js
+++ b/src/reflex.js
@@ -9,3 +9,13 @@ export const utils = srcUtils
 export { default as Col } from './derived/col'
 export { default as Root } from './derived/root'
 export { default as Offset } from './derived/offset'
+export type {
+  Size,
+  AlignGrid,
+  Justify,
+  Fixed,
+  Overflow,
+  Height,
+  Dev,
+  SpacingProps,
+} from './types'

--- a/storybook/index.js
+++ b/storybook/index.js
@@ -3,7 +3,7 @@ import React from 'react'
 import { each } from 'lodash'
 import { storiesOf } from '@storybook/react'
 import { withKnobs } from '@storybook/addon-knobs'
-import { utils } from '../src'
+import { utils } from '../src/reflex'
 import { storyFolders, WithExtensions, getName } from './shared'
 
 /**

--- a/storybook/stories/components/search/results.js
+++ b/storybook/stories/components/search/results.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react'
-import { Col, Grid } from 'reflex'
+import { Col, Grid, type Size } from 'reflex'
 import { times } from 'lodash'
 import styles from '../../../shared/stories.css'
 
@@ -11,7 +11,7 @@ export default function SearchResults({
 }: {
   results?: number,
   pages?: number,
-  size?: number,
+  size?: Size,
 }) {
   return (
     <Grid size={size} dev={5} align="top">

--- a/yarn.lock
+++ b/yarn.lock
@@ -1840,7 +1840,7 @@ chalk@^2.0.0, chalk@^2.0.1:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
-chokidar@^1.4.3, chokidar@^1.6.1:
+chokidar@^1.4.3, chokidar@^1.6.1, chokidar@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
   dependencies:
@@ -3535,9 +3535,19 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@0.49.1:
-  version "0.49.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.49.1.tgz#c9e456b3173a7535a4ffaf28956352c63bb8e3e9"
+flow-bin@0.51.0:
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.51.0.tgz#97a3c511a17caa25d8fad58fc17aaabcb86319fe"
+
+flow-copy-source@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/flow-copy-source/-/flow-copy-source-1.2.0.tgz#0ce7267cca593e347da69fcf75f82a768291e730"
+  dependencies:
+    chokidar "^1.7.0"
+    fs-extra "^3.0.1"
+    glob "^7.0.0"
+    kefir "^3.2.0"
+    yargs "^8.0.2"
 
 flush-write-stream@^1.0.0:
   version "1.0.2"
@@ -5124,6 +5134,12 @@ jsprim@^1.2.2:
 jsx-ast-utils@^1.4.0, jsx-ast-utils@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"
+
+kefir@^3.2.0:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/kefir/-/kefir-3.7.3.tgz#c1d4e0a7a9f63cfd73720ae38e0630c14784ed97"
+  dependencies:
+    symbol-observable "1.0.4"
 
 keycode@^2.1.8:
   version "2.1.9"
@@ -9020,7 +9036,7 @@ svgo@^0.7.0:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
-symbol-observable@^1.0.1, symbol-observable@^1.0.3:
+symbol-observable@1.0.4, symbol-observable@^1.0.1, symbol-observable@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
@@ -9909,7 +9925,7 @@ yargs@^7.0.2:
     y18n "^3.2.1"
     yargs-parser "^5.0.0"
 
-yargs@^8.0.1:
+yargs@^8.0.1, yargs@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
   dependencies:


### PR DESCRIPTION
- adds build step to copy src files and output to dist as `*.flow`. These files will be picked up by `flow` when type checking
- fixed an issue with flow config where flow was looking at dist for `reflex` components. Although, this could theoretically be resolved by the new build step implemented here.

Resolves https://github.com/obartra/reflex/issues/144