### PR TITLE
fix(build): target correct file path for CSS flow

### DIFF
--- a/scripts/deploynpm.sh
+++ b/scripts/deploynpm.sh
@@ -8,7 +8,7 @@ yarn
 yarn build
 
 # remove content from *.css.flow files so they are stubbed out and not parsed by flow
-node ./generateCssFlow.js
+node ./scripts/generateCssFlow.js
 
 # It will fail if the same version is deployed (e.g. readme changes won't up the version).
 # It should fail because we don't want to redeploy in that case so we just hide the error


### PR DESCRIPTION
I missed the fact that CI runs scripts from the root of the project rather than the relative path between shell script and node script.