### PR TITLE
feat(grid8): Update Base to take a base unit

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -2,17 +2,37 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { compact } from 'lodash'
-import type { Dev, AlignGrid, Justify, Size } from './types'
+import type {
+  Dev,
+  AlignGrid,
+  Justify,
+  Size,
+  SpacingValues,
+  Spacing,
+} from './types'
 import styles from './base.css'
 import devStyles from './dev.css'
+import { combineSpacing } from './utils'
 
 export type Props = {
-  dev?: Dev,
   align?: AlignGrid,
+  base?: number,
   children?: React$Element<any> | Array<React$Element<any>>,
   className?: string,
+  dev?: Dev,
   justify?: Justify,
+  margin?: Spacing,
+  marginBottom?: SpacingValues,
+  marginLeft?: SpacingValues,
+  marginRight?: SpacingValues,
+  marginTop?: SpacingValues,
+  padding?: Spacing,
+  paddingBottom?: SpacingValues,
+  paddingLeft?: SpacingValues,
+  paddingRight?: SpacingValues,
+  paddingTop?: SpacingValues,
   size?: Size,
+  style?: { [string]: string | number },
   style?: { [string]: string | number },
 }
 
@@ -22,16 +42,32 @@ export default class Base extends React.Component {
     devMode: PropTypes.bool,
   }
 
+  static defaultProps = {
+    style: {},
+  }
+
   props: Props
 
   render() {
     const {
-      dev,
       align,
       children,
       className,
+      dev,
+      base,
       justify,
       size,
+      style,
+      margin,
+      marginBottom,
+      marginLeft,
+      marginRight,
+      marginTop,
+      padding,
+      paddingBottom,
+      paddingLeft,
+      paddingRight,
+      paddingTop,
       ...props
     } = this.props
 
@@ -47,9 +83,27 @@ export default class Base extends React.Component {
       align && styles[`${align}Align`],
       justify && styles[`${justify}Justify`],
     ])
+    const cssStyle = {
+      ...style,
+      ...combineSpacing(
+        {
+          margin,
+          padding,
+          marginTop,
+          marginRight,
+          marginBottom,
+          marginLeft,
+          paddingTop,
+          paddingRight,
+          paddingBottom,
+          paddingLeft,
+        },
+        base
+      ),
+    }
 
     return (
-      <div {...props} className={classes.join(' ')}>
+      <div {...props} className={classes.join(' ')} style={cssStyle}>
         {children}
       </div>
     )

--- a/src/base.js
+++ b/src/base.js
@@ -16,7 +16,6 @@ import { combineSpacing } from './utils'
 
 export type Props = {
   align?: AlignGrid,
-  base?: number,
   children?: React$Element<any> | Array<React$Element<any>>,
   className?: string,
   dev?: Dev,
@@ -46,18 +45,16 @@ export default class Base extends React.Component {
     style: {},
   }
 
-  props: Props
+  props: Props & { base: number }
 
   render() {
     const {
       align,
+      base,
       children,
       className,
       dev,
-      base,
       justify,
-      size,
-      style,
       margin,
       marginBottom,
       marginLeft,
@@ -68,6 +65,8 @@ export default class Base extends React.Component {
       paddingLeft,
       paddingRight,
       paddingTop,
+      size,
+      style,
       ...props
     } = this.props
 

--- a/src/derived/col.js
+++ b/src/derived/col.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react'
 import Grid from '../grid'
-import type { Props } from '../grid'
+import type { Props } from '../base'
 import { validateSpacingProps } from '../utils'
 
 const defaults = {

--- a/src/derived/grid8.js
+++ b/src/derived/grid8.js
@@ -1,7 +1,0 @@
-// @flow
-import React from 'react'
-import Base from '../base'
-
-export default function Grid(props: {}) {
-  return <Base {...props} base={8} />
-}

--- a/src/derived/grid8.js
+++ b/src/derived/grid8.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react'
-import Base from './base'
+import Base from '../base'
 
 export default function Grid(props: {}) {
-  return <Base {...props} base={24} />
+  return <Base {...props} base={8} />
 }

--- a/src/layout.js
+++ b/src/layout.js
@@ -113,13 +113,16 @@ export default class Layout extends React.Component {
         className={classes.join(' ')}
         style={{
           ...style,
-          ...combineSpacing({
-            margin,
-            marginTop,
-            marginRight,
-            marginBottom,
-            marginLeft,
-          }),
+          ...combineSpacing(
+            {
+              margin,
+              marginTop,
+              marginRight,
+              marginBottom,
+              marginLeft,
+            },
+            24
+          ),
         }}
       />
     )

--- a/src/reflex.js
+++ b/src/reflex.js
@@ -1,11 +1,13 @@
 // @flow
 import * as srcUtils from './utils'
 
+export { default as Base } from './base'
 export { default as Grid } from './grid'
 export { default as Layout } from './layout'
 export { version } from '../version'
 export const utils = srcUtils
 
+export { default as Grid8 } from './derived/grid8'
 export { default as Col } from './derived/col'
 export { default as Root } from './derived/root'
 export { default as Offset } from './derived/offset'

--- a/src/reflex.js
+++ b/src/reflex.js
@@ -7,7 +7,6 @@ export { default as Layout } from './layout'
 export { version } from '../version'
 export const utils = srcUtils
 
-export { default as Grid8 } from './derived/grid8'
 export { default as Col } from './derived/col'
 export { default as Root } from './derived/root'
 export { default as Offset } from './derived/offset'

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,13 +1,12 @@
 // @flow
 import { memoize } from 'lodash'
-import type { Spacing, SpacingValues, Component, SpacingProps } from './types'
+import type { Spacing, Component, SpacingProps } from './types'
 
 /* eslint-disable no-unused-vars */
 const noop = (...params: any[]) => null
 /* eslint-enable no-unused-vars */
 const isProd = process.env.NODE_ENV === 'production'
 const isNumber = keys => key => typeof keys[key] === 'number'
-const gutter = 24
 
 /* eslint-disable no-console */
 export const log = {
@@ -92,20 +91,23 @@ export const getSpacingClasses = memoize(
   (values, type) => type + values.toString()
 )
 
-function getCSS(prop, value) {
+function getCSS(prop, value, base) {
   if (typeof value === 'undefined') {
     return {}
   } else if (prop.includes('padding')) {
-    return { [prop]: value * gutter }
+    return { [prop]: value * base }
   } else if (prop.includes('margin')) {
     return {
-      [`${prop.replace('margin', 'border')}Width`]: value * gutter,
+      [`${prop.replace('margin', 'border')}Width`]: value * base,
     }
   }
   throw new Error(`Invalid css prop: ${prop}`)
 }
 
-export function combineSpacing({ margin, padding, ...props }: SpacingProps) {
+export function combineSpacing(
+  { margin, padding, ...props }: SpacingProps,
+  base: number
+) {
   if (!validateSpacingProps({ margin, padding, ...props })) {
     return {}
   }
@@ -119,20 +121,8 @@ export function combineSpacing({ margin, padding, ...props }: SpacingProps) {
   return Object.keys(flatProps).reduce(
     (acc, prop) => ({
       ...acc,
-      ...getCSS(prop, flatProps[prop]),
+      ...getCSS(prop, flatProps[prop], base),
     }),
     {}
   )
-}
-
-export function toPx(
-  gutterFraction?: Spacing | SpacingValues
-): SpacingValues | void {
-  return typeof gutterFraction === 'number'
-    ? gutterFraction * gutter
-    : undefined
-}
-
-export function toPxArray(array?: Spacing | SpacingValues): Spacing | void {
-  return array instanceof Array ? (array.map(toPx): any) : undefined
 }

--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -1,43 +1,17 @@
-import {
-  log,
-  toPx,
-  toPxArray,
-  combineSpacing,
-  validateSpacingProps,
-} from './utils'
+import { log, combineSpacing, validateSpacingProps } from './utils'
 
-const gutter = 24
-
-describe('toPx', () => {
-  it('should not modify undefined values', () => {
-    expect(toPx()).toBe(undefined)
-    expect(toPx(undefined)).toBe(undefined)
-  })
-
-  it('should multiply input by base (8)', () => {
-    expect(toPx(2)).toBe(48)
-    expect(toPx(200.5)).toBe(200.5 * gutter)
-  })
-})
-
-describe('toPxArray', () => {
-  it('should not modify undefined values', () => {
-    expect(toPxArray([])).toEqual([])
-    expect(toPxArray([undefined, undefined])).toEqual([undefined, undefined])
-  })
-
-  it('should multiply input by base (8)', () => {
-    expect(toPxArray([2, 1, 0.5])).toEqual([48, 24, 12])
-  })
-})
+const base = 24
 
 describe('combineSpacing', () => {
   it('should combine valid spacing props', () => {
     expect(
-      combineSpacing({
-        marginTop: 1,
-        marginBottom: 2,
-      })
+      combineSpacing(
+        {
+          marginTop: 1,
+          marginBottom: 2,
+        },
+        base
+      )
     ).toEqual({
       borderBottomWidth: 48,
       borderTopWidth: 24,

--- a/storybook/stories/components/search/filters.js
+++ b/storybook/stories/components/search/filters.js
@@ -1,8 +1,9 @@
 // @flow
 import React from 'react'
 import { Col, Grid } from 'reflex'
+import type { Size } from '../../../../src/types'
 
-export default function SearchFilters(props: { size?: number }) {
+export default function SearchFilters(props: { size?: Size }) {
   return (
     <Col {...props} dev={4} align="top">
       <Col marginLeft={0}>Filter by</Col>


### PR DESCRIPTION
With base now it's easy to create additional grids with different bases.

Grid8 would allow us to implement things like small cards without either having
to directly set css or use imprecise fractions