### PR TITLE
feat(dev): Allow override dev mode toggles

### DIFF
--- a/src/dev.js
+++ b/src/dev.js
@@ -1,22 +1,25 @@
 // @flow
 import styles from './dev.css'
+import { noop } from './utils'
 
 const KEY_CODE_K = 75
 const KEY_CODE_S = 83
-const noop = () => null
 const body = ((document: any).body: HTMLElement)
 
-function toggleColor() {
-  body.classList.toggle('reflex-color-mode')
+function toggleColor(force?: boolean) {
+  body.classList.toggle('reflex-color-mode', force)
 }
 
-function toggleOverlayMode(overlay) {
-  if (body.contains(overlay)) {
-    body.classList.remove('reflex-dev-mode')
-    body.removeChild(overlay)
-  } else {
-    body.classList.add('reflex-dev-mode')
+function toggleOverlayMode(overlay, force?: boolean) {
+  const hasOverlay = body.contains(overlay)
+  const set = typeof force === 'undefined' ? !hasOverlay : force
+
+  body.classList.toggle('reflex-dev-mode', set)
+
+  if (set && !hasOverlay) {
     body.appendChild(overlay)
+  } else if (!set && hasOverlay) {
+    body.removeChild(overlay)
   }
 }
 

--- a/src/types.js
+++ b/src/types.js
@@ -1,6 +1,8 @@
 // @flow
 type zeroThroughEleven = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11
 
+export type Noop = (...params: any[]) => null
+
 export type Offset = zeroThroughEleven | void
 
 export type Size = zeroThroughEleven | 12 | 'fit' | 'auto' | void

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,12 +1,11 @@
 // @flow
 import { memoize } from 'lodash'
-import type { Component, SpacingProps } from './types'
+import type { Component, SpacingProps, Noop } from './types'
 
-/* eslint-disable no-unused-vars */
-const noop = (...params: any[]) => null
-/* eslint-enable no-unused-vars */
 const isProd = process.env.NODE_ENV === 'production'
 const isNumber = keys => key => typeof keys[key] === 'number'
+
+export const noop: Noop = () => null
 
 /* eslint-disable no-console */
 export const log = {

--- a/storybook/index.js
+++ b/storybook/index.js
@@ -8,7 +8,7 @@ import { storyFolders, WithExtensions } from './shared'
 
 const { toggleColor } = initDevMode({ force: true })
 
-toggleColor()
+toggleColor(true)
 
 /**
  * storyFolders dynamically fetches all files within `/stories`


### PR DESCRIPTION
Add boolean override parameter to `toggleOverlay()` and `toggleColor()` to force setting or unsetting (instead of toggling) a mode.

This behavior mimics jQuery or and DOM API's (e.g. `$().toggleClass` and `classList.toggle`) so it should be familiar for consumers.

Additionally, this is important for hot reloading where the setup code may runs multiple times and would otherwise keep toggling colors on and off

Closes https://github.com/obartra/reflex/issues/258