### PR TITLE
fix(withGrid): match export name to file name

### DIFF
--- a/scripts/webpack.config.js
+++ b/scripts/webpack.config.js
@@ -68,7 +68,7 @@ module.exports = {
   devtool: 'source-map',
   externals: {
     react: 'react',
-    'prop-types': 'PropTypes',
+    'prop-types': 'prop-types',
   },
   module: {
     rules: [

--- a/src/reflex.js
+++ b/src/reflex.js
@@ -1,7 +1,10 @@
 // @flow
+import { type Props } from './withBase'
 import * as srcUtils from './utils'
 
-export { default as withCol } from './withGrid'
+export type GridProps = Props
+
+export { default as withGrid } from './withGrid'
 export { default as withBase } from './withBase'
 export { default as Base } from './base'
 export { default as Grid } from './grid'
@@ -13,6 +16,7 @@ export { default as Col } from './derived/col'
 export { default as Root } from './derived/root'
 export { default as Offset } from './derived/offset'
 export { default as initDevMode } from './dev'
+
 export type {
   Size,
   AlignGrid,


### PR DESCRIPTION
- webpack `external` wasn't properly pointing to the correct dependency
- export was improperly named
- added `GridProps` type to export as a helper for types

BREAKING CHANGE