### PR TITLE
feat(grid): allow modifying base prop

### DIFF
--- a/src/grid.js
+++ b/src/grid.js
@@ -4,7 +4,7 @@ import type { Props as GridProps } from './withBase'
 import Base from './base'
 
 function Grid(props: GridProps) {
-  return <Base {...props} base={24} />
+  return <Base base={24} {...props} />
 }
 
 export default Grid


### PR DESCRIPTION
currently Grid forces base to be 24. This should still be the default, but it should be overridable.

While this change is not breaking, this is being labelled as a breaking change since a previous commit, https://github.com/obartra/reflex/commit/cefbbe61c038e7ccadd36aa901ba0ba4c6cc5251 did not get tracked properly as breaking, and the major version was not bumped.

BREAKING CHANGE