### PR TITLE
ci(bithound): Remove bithound check

### DIFF
--- a/scripts/citests.sh
+++ b/scripts/citests.sh
@@ -10,7 +10,6 @@ echo "Running node $CIRCLE_NODE_INDEX"
 
 if [ "$CIRCLE_NODE_INDEX" -eq "0" ]; then
   yarn test:size                          # Validate bundle gzipped size
-  yarn test:bithound                      # Analyze code with bithound
   yarn lint                               # Validate linting
   yarn test -- --coverage                 # Validate unit tests
   cat ./coverage/lcov.info | node_modules/.bin/codeclimate-test-reporter


### PR DESCRIPTION
Test is currently failing on reflex/master. Disabling from CI since it's only
failing there and it's already part of the PR checks