### PR TITLE
fix(flow): allow valid number strings

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -1,11 +1,12 @@
 // @flow
-type zeroThroughEleven = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11
+type zeroThroughElevenNumbers = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11
+type zeroThroughElevenStrings = '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11'
 
 export type Noop = (...params: any[]) => null
 
-export type Offset = zeroThroughEleven | void
+export type Offset = zeroThroughElevenNumbers | zeroThroughElevenStrings | void
 
-export type Size = zeroThroughEleven | 12 | 'fit' | 'auto' | void
+export type Size = zeroThroughElevenNumbers | zeroThroughElevenStrings | 12 | '12' | 'fit' | 'auto' | void
 
 export type Dev = 1 | 2 | 3 | 4 | 5 | void
 


### PR DESCRIPTION
`size` and `offset` props can also accept strings. But flow currently sees this as an error.