### PR TITLE
ci(renovate): Re-enable renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,16 @@
 {
-  "extends": [":library"]
+  "schedule": "after 10pm on sunday",
+  "pinVersions": true,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": "after 10pm on sunday"
+  },
+  "automerge": true,
+  "major": {
+    "automerge": false
+  },
+  "devDependencies": {
+    "automerge": true
+  },
+  "rebaseStalePrs": true
 }


### PR DESCRIPTION
Re-enables renovate but configures it to only run once a week. This is the minimum frequency we can set. If this still becomes too noisy I'll disable renovate altogether. Manual updates have been working well and with our current test coverage there's little manual work to do anyways.

Closes https://github.com/obartra/reflex/issues/269