### PR TITLE
feat(grid): expose underlying ref for grids

### DIFF
--- a/src/grid/asGrid.js
+++ b/src/grid/asGrid.js
@@ -33,6 +33,7 @@ export default function asGrid(Component: *) {
       children,
       className,
       dev,
+      innerRef,
       justify,
       margin,
       marginBottom,
@@ -83,7 +84,12 @@ export default function asGrid(Component: *) {
     }
 
     return (
-      <Component {...props} className={classes.join(' ')} style={cssStyle}>
+      <Component
+        ref={innerRef}
+        {...props}
+        className={classes.join(' ')}
+        style={cssStyle}
+      >
         {children}
       </Component>
     )

--- a/src/grid/grid.spec.js
+++ b/src/grid/grid.spec.js
@@ -21,6 +21,13 @@ describe('gridHOC', () => {
     expect(wrapper.html()).toEqual(gridWrapper.html())
   })
 
+  it('should pass a ref to innerRef', () => {
+    const spy = jest.fn()
+    const Div = asGrid('div')
+    wrapper = mount(<Div innerRef={spy} />)
+    expect(spy).toHaveBeenCalledWith(wrapper.find('div').instance())
+  })
+
   afterEach(() => {
     if (wrapper) {
       wrapper.unmount()


### PR DESCRIPTION
Having access to the underlying DOM node can be useful for executing side effects as well as measurements on the DOM.