### PR TITLE
fix(npm): Correct npm targets

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,4 @@
 [ignore]
-<PROJECT_ROOT>/dist
 .*/node_modules/conventional-changelog-core/test
 .*/node_modules/editions/.*
 .*/node_modules/radium/.*

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+// @flow
 /* eslint-disable global-require */
 if (process.env.NODE_ENV === 'production') {
   module.exports = require('./dist/reflex.min.js')

--- a/index.js
+++ b/index.js
@@ -1,0 +1,6 @@
+/* eslint-disable global-require */
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./dist/reflex.min.js')
+} else {
+  module.exports = require('./dist/reflex.js')
+}

--- a/package.json
+++ b/package.json
@@ -2,9 +2,8 @@
   "name": "xn-reflex",
   "version": "0.0.0-semantically-released",
   "description": "Flexbox React 12-column layout system",
-  "module": "src/index.js",
-  "main": "dist/reflex.js",
-  "browser": "dist/reflex.js",
+  "main": "index.js",
+  "browser": "dist/reflex.min.js",
   "homepage": "https://obartra.github.io/reflex",
   "files": [
     "package.json",
@@ -12,7 +11,8 @@
     "LICENSE",
     "src",
     "dist",
-    "version.js"
+    "version.js",
+    "index.js"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Remove `module` since although we can offer an ES6 build, it has additional (unlisted) dependencies: `cxs`, `preval`
- Default to a new `index.js` file that decides which file to serve based on `NODE_ENV` (similar to React's [approach](https://github.com/facebook/react/blob/master/packages/react/npm/index.js))
- Preserve the `browser` section from `package.json` but make it point to the minified build by default (this is useful for tools like unpkg, that will use it to load the minified version instead when importing https://unpkg.com/xn-reflex)